### PR TITLE
Combine grocery extensions with launcher

### DIFF
--- a/inventoryTimeline.css
+++ b/inventoryTimeline.css
@@ -1,0 +1,9 @@
+body { font-family: Arial, sans-serif; width: 600px; overflow-x: auto; }
+#controls { margin-bottom: 10px; }
+#grid-container { overflow-x: auto; }
+table { border-collapse: collapse; }
+th, td { border: 1px solid #ccc; padding: 2px 4px; text-align: center; }
+.green { background-color: #c8e6c9; }
+.yellow { background-color: #fff9c4; }
+.red { background-color: #ffcdd2; }
+.exp-weeks { font-size: 0.8em; color: #666; }

--- a/inventoryTimeline.html
+++ b/inventoryTimeline.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Grocery Timeline</title>
+  <link rel="stylesheet" href="inventoryTimeline.css">
+</head>
+<body>
+  <h1>Grocery Inventory Timeline</h1>
+  <div id="controls">
+    <label>Item:
+      <input type="text" id="purchase-item" list="item-list" />
+      <datalist id="item-list"></datalist>
+    </label>
+    <label>Week:
+      <input type="number" id="purchase-week" min="1" max="52" value="1" />
+    </label>
+    <label>Qty:
+      <input type="number" id="purchase-qty" value="1" />
+    </label>
+    <button id="add-purchase">Add Purchase</button>
+    <button id="view-purchases">Purchase History</button>
+  </div>
+  <div id="grid-container"></div>
+  <script src="inventoryTimeline.js"></script>
+</body>
+</html>

--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -1,0 +1,236 @@
+async function loadJSON(path) {
+  const url = chrome.runtime.getURL(path);
+  const res = await fetch(url);
+  return res.json();
+}
+
+async function loadPurchases() {
+  return new Promise(resolve => {
+    try {
+      chrome.storage.local.get('purchases', data => {
+        resolve(data.purchases || {});
+      });
+    } catch (e) {
+      // fallback if chrome is not available
+      resolve({});
+    }
+  });
+}
+
+async function savePurchases(map) {
+  return new Promise(resolve => {
+    try {
+      chrome.storage.local.set({ purchases: map }, () => resolve());
+    } catch (e) {
+      resolve();
+    }
+  });
+}
+
+async function loadData() {
+  const [needs, expiration, stock] = await Promise.all([
+    loadJSON('Required for grocery app/yearly_needs_with_manual_flags.json'),
+    loadJSON('Required for grocery app/expiration_times_full.json'),
+    loadJSON('Required for grocery app/current_stock_table.json')
+  ]);
+  return { needs, expiration, stock };
+}
+
+function buildItemMap(needs, expiration, stock) {
+  const expMap = {};
+  expiration.forEach(e => { expMap[e.name] = e.shelf_life_months * 4.33; });
+  const stockMap = {};
+  stock.forEach(s => { stockMap[s.name] = s.amount; });
+
+  return needs.map(n => ({
+    name: n.name,
+    units_per_purchase: 1,
+    weekly_consumption: n.total_needed_year / 52,
+    expiration_weeks: expMap[n.name] || 52,
+    starting_stock: stockMap[n.name] || 0,
+    purchases: []
+  }));
+}
+
+function simulateItem(item, overrides) {
+  const incoming = [];
+  const active = [];
+  // initial stock treated as purchase at week 1
+  if (item.starting_stock > 0) {
+    incoming.push({ start: 1, qty: item.starting_stock, exp: 1 + item.expiration_weeks });
+  }
+  item.purchases.forEach(p => {
+    const exp = p.manual_expiration_override || item.expiration_weeks;
+    incoming.push({ start: p.purchase_week, qty: p.quantity_purchased, exp: p.purchase_week + exp });
+  });
+  incoming.sort((a,b)=>a.start-b.start);
+
+  const weeks = [];
+  let runoutWeek = null;
+  for (let w=1; w<=52; w++) {
+    // move incoming purchases into active inventory
+    while (incoming.length && incoming[0].start <= w) {
+      active.push(incoming.shift());
+    }
+    // sort by soonest expiration for processing
+    active.sort((a,b)=>a.exp-b.exp);
+    // remove expired batches
+    while (active.length && w >= active[0].exp) {
+      active.shift();
+    }
+    let qty = active.reduce((sum,b)=>sum+b.qty,0);
+    const cons = (overrides[w]!==undefined ? overrides[w] : 1) * item.weekly_consumption;
+    let remaining = cons;
+    while (active.length && remaining>0) {
+      if (active[0].qty > remaining) {
+        active[0].qty -= remaining;
+        remaining = 0;
+      } else {
+        remaining -= active[0].qty;
+        active.shift();
+      }
+    }
+    qty = active.reduce((sum,b)=>sum+b.qty,0);
+    const closestExp = active.length ? Math.min(...active.map(b=>b.exp)) : w;
+    const weeksToExpiration = closestExp - w;
+    const weeksToRunout = qty > 0 ? qty / item.weekly_consumption : 0;
+    if (qty <= 0 && runoutWeek===null) runoutWeek = w;
+    let cls = 'green';
+    if (qty <= 0 || weeksToExpiration <= 0) {
+      cls = 'red';
+    } else if (qty < item.weekly_consumption*2 || weeksToExpiration < item.expiration_weeks*0.1) {
+      cls = 'yellow';
+    }
+    weeks.push({ qty: qty.toFixed(1), weeksToExpiration: Math.floor(weeksToExpiration), cls });
+  }
+  return weeks;
+}
+
+function buildGrid(items) {
+  const grid = document.createElement('table');
+  const header = document.createElement('tr');
+  const firstTh = document.createElement('th');
+  firstTh.textContent = 'Item';
+  header.appendChild(firstTh);
+  for (let w=1; w<=52; w++) {
+    const th = document.createElement('th');
+    th.textContent = w;
+    header.appendChild(th);
+  }
+  grid.appendChild(header);
+
+  items.forEach(item => {
+    const overrides = {};
+    if (item.overrideWeeks) Object.assign(overrides, item.overrideWeeks);
+    const weeks = simulateItem(item, overrides);
+    const row = document.createElement('tr');
+    const th = document.createElement('th');
+    th.innerHTML = `${item.name}<br/><span class="exp-weeks">${item.expiration_weeks}w</span>`;
+    row.appendChild(th);
+    weeks.forEach(w => {
+      const td = document.createElement('td');
+      td.className = w.cls;
+      td.innerHTML = `${w.qty}<br/>⏰ ${w.weeksToExpiration}`;
+      row.appendChild(td);
+    });
+    grid.appendChild(row);
+  });
+  return grid;
+}
+
+function buildPurchaseList(items) {
+  const container = document.createElement('div');
+  items.forEach(item => {
+    if (!item.purchases.length) return;
+    const header = document.createElement('h3');
+    header.textContent = item.name;
+    container.appendChild(header);
+    const ul = document.createElement('ul');
+    item.purchases.forEach((p, idx) => {
+      const li = document.createElement('li');
+      const date = new Date(p.date_added).toLocaleDateString();
+      li.textContent = `Week ${p.purchase_week} - Qty ${p.quantity_purchased} - ${date} `;
+      const btn = document.createElement('button');
+      btn.textContent = 'X';
+      btn.addEventListener('click', () => {
+        item.purchases.splice(idx, 1);
+        saveAllPurchases(items);
+        showPurchaseHistory();
+      });
+      li.appendChild(btn);
+      ul.appendChild(li);
+    });
+    container.appendChild(ul);
+  });
+  return container;
+}
+
+function saveAllPurchases(items) {
+  const map = {};
+  items.forEach(it => { if (it.purchases.length) map[it.name] = it.purchases; });
+  savePurchases(map);
+}
+
+let showingHistory = false;
+let globalItems = [];
+let gridContainer;
+
+function showGrid() {
+  showingHistory = false;
+  document.getElementById('view-purchases').textContent = 'Purchase History';
+  gridContainer.innerHTML = '';
+  gridContainer.appendChild(buildGrid(globalItems));
+}
+
+function showPurchaseHistory() {
+  showingHistory = true;
+  document.getElementById('view-purchases').textContent = 'Timeline View';
+  gridContainer.innerHTML = '';
+  gridContainer.appendChild(buildPurchaseList(globalItems));
+}
+
+async function init() {
+  const data = await loadData();
+  const items = buildItemMap(data.needs, data.expiration, data.stock);
+  const savedMap = await loadPurchases();
+  items.forEach(it => {
+    if (savedMap[it.name]) {
+      it.purchases = savedMap[it.name];
+    }
+  });
+  const datalist = document.getElementById('item-list');
+  items.forEach(it => {
+    const opt = document.createElement('option');
+    opt.value = it.name;
+    datalist.appendChild(opt);
+  });
+
+  gridContainer = document.getElementById('grid-container');
+  globalItems = items;
+  showGrid();
+
+  document.getElementById('view-purchases').addEventListener('click', () => {
+    if (showingHistory) {
+      showGrid();
+    } else {
+      showPurchaseHistory();
+    }
+  });
+
+  document.getElementById('add-purchase').addEventListener('click', () => {
+    const name = document.getElementById('purchase-item').value;
+    const week = parseInt(document.getElementById('purchase-week').value,10);
+    const qty = parseFloat(document.getElementById('purchase-qty').value);
+    const item = globalItems.find(i => i.name===name);
+    if (!item) return;
+    item.purchases.push({ purchase_week: week, quantity_purchased: qty, date_added: new Date().toISOString() });
+    saveAllPurchases(globalItems);
+    if (showingHistory) {
+      showPurchaseHistory();
+    } else {
+      showGrid();
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/launcher.html
+++ b/launcher.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Grocery Extension</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 200px; }
+    button { width: 100%; margin: 5px 0; }
+  </style>
+</head>
+<body>
+  <button id="open-price-checker">Price Checker</button>
+  <button id="open-inventory-timeline">Inventory Timeline</button>
+  <script src="launcher.js"></script>
+</body>
+</html>

--- a/launcher.js
+++ b/launcher.js
@@ -1,0 +1,12 @@
+function openWindow(path) {
+  const url = chrome.runtime.getURL(path);
+  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+}
+
+document.getElementById('open-price-checker').addEventListener('click', () => {
+  openWindow('popup.html');
+});
+
+document.getElementById('open-inventory-timeline').addEventListener('click', () => {
+  openWindow('inventoryTimeline.html');
+});

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
     "https://www.hannaford.com/*"
   ],
   "action": {
-    "default_popup": "popup.html"
+    "default_popup": "launcher.html"
   },
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
## Summary
- add launcher popup with buttons to open each tool
- integrate GroceryInventory as Inventory Timeline window
- link Inventory Timeline data to existing datasets
- update manifest to use the launcher popup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851bd9730f483299344858083b02789