### PR TITLE
Add week-based stock calculation

### DIFF
--- a/utils/purchaseCalculator.js
+++ b/utils/purchaseCalculator.js
@@ -1,14 +1,28 @@
+import { getStockForWeek } from './timeline.js';
+
 export function calculatePurchaseNeeds(
   needs,
   consumption,
   stock,
   expiration,
-  consumedYear = []
+  consumedYear = [],
+  purchases = {},
+  week = 1
 ) {
-  const stockMap = new Map(stock.map(i => [i.name, i]));
   const consMap = new Map(consumption.map(i => [i.name, i]));
   const expMap = new Map(expiration.map(i => [i.name, i]));
   const consumedMap = new Map(consumedYear.map(i => [i.name, i]));
+
+  const timelineItems = needs.map(item => ({
+    name: item.name,
+    weekly_consumption:
+      (consMap.get(item.name)?.monthly_consumption ?? 0) / 4.33,
+    expiration_weeks: (expMap.get(item.name)?.shelf_life_months ?? 12) * 4.33,
+    starting_stock: stock.find(s => s.name === item.name)?.amount ?? 0
+  }));
+
+  const futureStock = getStockForWeek(timelineItems, purchases, week);
+  const stockMap = new Map(futureStock.map(i => [i.name, i]));
 
   return needs.map(item => {
     const cons = consMap.get(item.name)?.monthly_consumption ?? 0;

--- a/utils/timeline.js
+++ b/utils/timeline.js
@@ -1,0 +1,44 @@
+export function getStockForWeek(items, purchases = {}, week = 1) {
+  return items.map(item => {
+    const simItem = {
+      ...item,
+      purchases: purchases[item.name] || []
+    };
+    const qty = simulateForWeek(simItem, week);
+    return { name: item.name, amount: qty };
+  });
+}
+
+function simulateForWeek(item, week) {
+  const incoming = [];
+  const active = [];
+  if (item.starting_stock > 0) {
+    incoming.push({ start: 1, qty: item.starting_stock, exp: 1 + item.expiration_weeks });
+  }
+  (item.purchases || []).forEach(p => {
+    const exp = p.manual_expiration_override || item.expiration_weeks;
+    incoming.push({ start: p.purchase_week, qty: p.quantity_purchased, exp: p.purchase_week + exp });
+  });
+  incoming.sort((a,b)=>a.start-b.start);
+
+  for (let w = 1; w <= week; w++) {
+    while (incoming.length && incoming[0].start <= w) {
+      active.push(incoming.shift());
+    }
+    active.sort((a,b)=>a.exp-b.exp);
+    while (active.length && w >= active[0].exp) {
+      active.shift();
+    }
+    let remaining = item.weekly_consumption;
+    while (active.length && remaining > 0) {
+      if (active[0].qty > remaining) {
+        active[0].qty -= remaining;
+        remaining = 0;
+      } else {
+        remaining -= active[0].qty;
+        active.shift();
+      }
+    }
+  }
+  return active.reduce((sum,b)=>sum+b.qty,0);
+}


### PR DESCRIPTION
## Summary
- create a timeline helper to project stock for a given week
- extend purchase calculator to use projected stock and accept purchases/week
- load purchases in popup and pass current week to calculator

## Testing
- `node -e "require('./utils/purchaseCalculator.js'); require('./utils/timeline.js'); console.log('ok')"`
- `node --check popup.js`
- `node --check utils/timeline.js`
- `node --check utils/purchaseCalculator.js`

------
https://chatgpt.com/codex/tasks/task_e_6851db3354dc832990e3fba17145b0c0