### PR TITLE
Filter popup items by weekly stock levels

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -105,6 +105,7 @@ async function init() {
     consumed
   );
   const purchaseMap = new Map(purchaseInfo.map(p => [p.name, p]));
+  const stockMap = new Map(stock.map(i => [i.name, i]));
   const itemsContainer = document.getElementById('items');
 
   needs.forEach(item => {
@@ -128,6 +129,9 @@ async function init() {
     finalImg.width = 50;
     finalImg.height = 50;
     finalImg.style.display = 'none';
+    const currentQty = stockMap.get(item.name)?.amount || 0;
+    const weeklyNeed = item.total_needed_year ? item.total_needed_year / 52 : 0;
+    li.style.display = currentQty < weeklyNeed ? 'list-item' : 'none';
     getFinal(item.name).then(async store => {
       const product = await getFinalProduct(item.name);
       if (store) {
@@ -154,7 +158,7 @@ async function init() {
     });
     li.appendChild(finalSpan);
     li.appendChild(finalImg);
-    finalMap.set(item.name, { btn, span: finalSpan, img: finalImg });
+    finalMap.set(item.name, { li, btn, span: finalSpan, img: finalImg });
     itemsContainer.appendChild(li);
   });
 }
@@ -204,6 +208,7 @@ async function refreshNeeds(stock = stockData, consumed = consumedYearData) {
     consumed
   );
   const purchaseMap = new Map(purchaseInfo.map(p => [p.name, p]));
+  const stockMap = new Map(stock.map(i => [i.name, i]));
   needsData.forEach(item => {
     const rec = finalMap.get(item.name);
     if (rec && rec.btn) {
@@ -212,6 +217,9 @@ async function refreshNeeds(stock = stockData, consumed = consumedYearData) {
       const amountText =
         info && !isNaN(needAmt) ? ` (Need: ${needAmt} ${info.home_unit})` : '';
       rec.btn.textContent = item.name + amountText;
+      const qty = stockMap.get(item.name)?.amount || 0;
+      const weekly = item.total_needed_year ? item.total_needed_year / 52 : 0;
+      rec.li.style.display = qty < weekly ? 'list-item' : 'none';
     }
   });
 }


### PR DESCRIPTION
## Summary
- in `popup.js` compute weekly consumption from yearly needs
- hide grocery items when weekly stock is sufficient
- keep list visibility updated when inventory changes

## Testing
- `node --check popup.js`

------
https://chatgpt.com/codex/tasks/task_e_6851db34897083298f47a83ce259988a