### PR TITLE
Add weekly consumption overrides

### DIFF
--- a/consumed.html
+++ b/consumed.html
@@ -7,6 +7,7 @@
     body { font-family: Arial, sans-serif; width: 300px; }
     .item { margin-bottom: 10px; }
     input[type="number"] { width: 60px; }
+    input.week-input { width: 50px; }
     ul.history { list-style: none; padding-left: 20px; margin-top: 5px; }
     ul.history li { font-size: 0.9em; }
     ul.history button { margin-left: 5px; }


### PR DESCRIPTION
## Summary
- add week-specific override input UI
- track consumption overrides per item and week
- persist overrides and load them in inventory timeline

## Testing
- `node -c consumed.js`
- `node -c inventoryTimeline.js`


------
https://chatgpt.com/codex/tasks/task_e_6851db362e4c8329986103e4f8d6a352