### PR TITLE
Add week field and record purchase on item creation

### DIFF
--- a/addItem.html
+++ b/addItem.html
@@ -32,6 +32,9 @@
   <div class="field">
     <label>Current Stock <input id="stock" type="number" step="any"></label>
   </div>
+  <div class="field">
+    <label>Week <input id="week" type="number" min="1" max="52"></label>
+  </div>
   <button id="commit">Commit</button>
   <script type="module" src="addItem.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- allow specifying creation week when adding a new item
- record initial stock as a purchase for that week

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6851db389cb48329a83431b28aed247e