### PR TITLE
Fix duplicate function definition in popup.js

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -294,13 +294,6 @@ function getPackCount(product) {
 }
 
 
-async function loadPurchases() {
-  return new Promise(resolve => {
-    chrome.storage.local.get('purchases', data => {
-      resolve(data.purchases || {});
-    });
-  });
-}
 
 async function savePurchases(map) {
   return new Promise(resolve => {


### PR DESCRIPTION
## Summary
- remove redundant `loadPurchases` function

## Testing
- `npx eslint *.js utils scrapers`

------
https://chatgpt.com/codex/tasks/task_e_6851e01e577c8329acc5b3e80229ee3d