### PR TITLE
Fix timeline refresh on consumption changes

### DIFF
--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -283,6 +283,19 @@ async function init() {
       });
       updated = true;
     }
+    if (changes.consumptionOverrides || changes.consumedThisYear) {
+      const overridesMap = (changes.consumptionOverrides && changes.consumptionOverrides.newValue) || {};
+      globalItems.forEach(it => {
+        const data = overridesMap[it.name] || {};
+        const weekMap = {};
+        Object.keys(data).forEach(w => {
+          const diff = data[w];
+          weekMap[w] = it.weekly_consumption ? diff / it.weekly_consumption : 0;
+        });
+        it.overrideWeeks = weekMap;
+      });
+      updated = true;
+    }
     if (updated) {
       if (showingHistory) {
         showPurchaseHistory();


### PR DESCRIPTION
## Summary
- update inventory timeline when consumption overrides change

## Testing
- `node -c inventoryTimeline.js`

------
https://chatgpt.com/codex/tasks/task_e_6851f4a994ec832999aef3f1dd3bb449