### PR TITLE
Fix override week calculation in timeline

### DIFF
--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -220,7 +220,9 @@ async function fetchItems() {
       const weekMap = {};
       Object.keys(overridesMap[it.name]).forEach(w => {
         const diff = overridesMap[it.name][w];
-        weekMap[w] = it.weekly_consumption ? diff / it.weekly_consumption : 0;
+        weekMap[w] = it.weekly_consumption
+          ? 1 + diff / it.weekly_consumption
+          : 1;
       });
       it.overrideWeeks = weekMap;
     }
@@ -314,8 +316,10 @@ async function init() {
         const data = overridesMap[it.name] || {};
         const weekMap = {};
         Object.keys(data).forEach(w => {
-          const diff = data[w];
-          weekMap[w] = it.weekly_consumption ? diff / it.weekly_consumption : 0;
+        const diff = data[w];
+        weekMap[w] = it.weekly_consumption
+          ? 1 + diff / it.weekly_consumption
+          : 1;
         });
         it.overrideWeeks = weekMap;
       });


### PR DESCRIPTION
## Summary
- adjust override calculation to add weekly consumption difference instead of replacing it

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68528dec36688329849791a159056898