### PR TITLE
Display weekly consumption info

### DIFF
--- a/GroceryInventory/extension/popup.js
+++ b/GroceryInventory/extension/popup.js
@@ -125,7 +125,8 @@ function buildGrid(items) {
     const weeks = simulateItem(item, overrides);
     const row = document.createElement('tr');
     const th = document.createElement('th');
-    th.innerHTML = `${item.name}<br/><span class="exp-weeks">${item.expiration_weeks}w</span>`;
+    th.innerHTML = `${item.name}<br/><span class="exp-weeks">${item.expiration_weeks}w</span>` +
+      `<br/><span class="weekly-cons">${item.weekly_consumption.toFixed(2)}/wk</span>`;
     row.appendChild(th);
     weeks.forEach(w => {
       const td = document.createElement('td');

--- a/GroceryInventory/extension/style.css
+++ b/GroceryInventory/extension/style.css
@@ -7,3 +7,4 @@ th, td { border: 1px solid #ccc; padding: 2px 4px; text-align: center; }
 .yellow { background-color: #fff9c4; }
 .red { background-color: #ffcdd2; }
 .exp-weeks { font-size: 0.8em; color: #666; }
+.weekly-cons { font-size: 0.8em; color: #666; }

--- a/consumed.js
+++ b/consumed.js
@@ -64,7 +64,7 @@ function saveHistory(hist) {
   });
 }
 
-function updateHistoryList(name, ul, span, map, history, overrides) {
+function updateHistoryList(name, ul, span, map, history, overrides, weekly) {
   ul.innerHTML = '';
   const entries = history[name] || [];
   entries.forEach(entry => {
@@ -75,7 +75,8 @@ function updateHistoryList(name, ul, span, map, history, overrides) {
     btn.addEventListener('click', async () => {
       const rec = map.get(name);
       rec.amount -= entry.diff;
-      span.textContent = `${rec.name} - ${rec.amount} ${rec.unit}`;
+      const weeklyText = weekly ? ` - ${weekly.toFixed(2)}/wk` : '';
+      span.textContent = `${rec.name} - ${rec.amount} ${rec.unit}${weeklyText}`;
       const arr = history[name] || [];
       const idx = arr.findIndex(e => e.id === entry.id);
       if (idx !== -1) arr.splice(idx, 1);
@@ -92,7 +93,7 @@ function updateHistoryList(name, ul, span, map, history, overrides) {
       await saveConsumption(Array.from(map.values()));
       await saveHistory(history);
       await saveOverrides(overrides);
-      updateHistoryList(name, ul, span, map, history, overrides);
+      updateHistoryList(name, ul, span, map, history, overrides, weekly);
     });
     li.appendChild(document.createTextNode(' '));
     li.appendChild(btn);
@@ -100,11 +101,12 @@ function updateHistoryList(name, ul, span, map, history, overrides) {
   });
 }
 
-function createItemRow(item, map, history, overrides) {
+function createItemRow(item, map, history, overrides, weekly) {
   const div = document.createElement('div');
   div.className = 'item';
   const span = document.createElement('span');
-  span.textContent = `${item.name} - ${item.amount} ${item.unit}`;
+  const weeklyText = weekly ? ` - ${weekly.toFixed(2)}/wk` : '';
+  span.textContent = `${item.name} - ${item.amount} ${item.unit}${weeklyText}`;
   div.appendChild(span);
 
   const input = document.createElement('input');
@@ -123,7 +125,8 @@ function createItemRow(item, map, history, overrides) {
       const week = parseInt(weekInput.value, 10);
       if (!isNaN(change) && !isNaN(week)) {
         item.amount += change;
-        span.textContent = `${item.name} - ${item.amount} ${item.unit}`;
+        const wkTxt = weekly ? ` - ${weekly.toFixed(2)}/wk` : '';
+        span.textContent = `${item.name} - ${item.amount} ${item.unit}${wkTxt}`;
         const arr = history[item.name] || [];
         arr.unshift({ id: Date.now(), date: new Date().toLocaleDateString(), diff: change, week });
         history[item.name] = arr;
@@ -132,7 +135,7 @@ function createItemRow(item, map, history, overrides) {
         await saveConsumption(Array.from(map.values()));
         await saveHistory(history);
         await saveOverrides(overrides);
-        updateHistoryList(item.name, ul, span, map, history, overrides);
+        updateHistoryList(item.name, ul, span, map, history, overrides, weekly);
         input.value = '';
         weekInput.value = '';
       }
@@ -146,7 +149,7 @@ function createItemRow(item, map, history, overrides) {
   const ul = document.createElement('ul');
   ul.className = 'history';
   div.appendChild(ul);
-  updateHistoryList(item.name, ul, span, map, history, overrides);
+  updateHistoryList(item.name, ul, span, map, history, overrides, weekly);
 
   return div;
 }
@@ -171,7 +174,8 @@ async function init() {
   // render in needs order
   needs.forEach(n => {
     const item = map.get(n.name);
-    const row = createItemRow(item, map, history, overrides);
+    const weekly = n.total_needed_year ? n.total_needed_year / 52 : 0;
+    const row = createItemRow(item, map, history, overrides, weekly);
     container.appendChild(row);
   });
   await saveConsumption(Array.from(map.values()));

--- a/inventoryTimeline.css
+++ b/inventoryTimeline.css
@@ -7,3 +7,4 @@ th, td { border: 1px solid #ccc; padding: 2px 4px; text-align: center; }
 .yellow { background-color: #fff9c4; }
 .red { background-color: #ffcdd2; }
 .exp-weeks { font-size: 0.8em; color: #666; }
+.weekly-cons { font-size: 0.8em; color: #666; }

--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -155,7 +155,8 @@ function buildGrid(items) {
     const weeks = simulateItem(item, overrides);
     const row = document.createElement('tr');
     const th = document.createElement('th');
-    th.innerHTML = `${item.name}<br/><span class="exp-weeks">${item.expiration_weeks}w</span>`;
+    th.innerHTML = `${item.name}<br/><span class="exp-weeks">${item.expiration_weeks}w</span>` +
+      `<br/><span class="weekly-cons">${item.weekly_consumption.toFixed(2)}/wk</span>`;
     row.appendChild(th);
     weeks.forEach(w => {
       const td = document.createElement('td');


### PR DESCRIPTION
## Summary
- show weekly consumption data on the inventory timeline grid
- display weekly consumption when editing yearly consumption

## Testing
- `node --check consumed.js`
- `node --check inventoryTimeline.js`
- `node --check GroceryInventory/extension/popup.js`


------
https://chatgpt.com/codex/tasks/task_e_685299bed5fc8329a52aa482255be59f