### PR TITLE
Add store selection for coupons

### DIFF
--- a/coupon.html
+++ b/coupon.html
@@ -8,6 +8,7 @@
     .item { margin-bottom: 10px; }
     input[type="number"] { width: 60px; }
     input.week { width: 50px; }
+    select { width: 110px; }
   </style>
 </head>
 <body>

--- a/coupon.js
+++ b/coupon.js
@@ -29,13 +29,16 @@ function saveCoupons(map) {
   });
 }
 
+const STORES = ['Stop & Shop', 'Walmart', 'Amazon', 'Shaws', 'Roche Bros', 'Hannaford'];
+
 function createList(itemName, couponsMap) {
   const ul = document.createElement('ul');
   function refresh() {
     ul.innerHTML = '';
     (couponsMap[itemName] || []).forEach((c, idx) => {
       const li = document.createElement('li');
-      li.textContent = `${c.type} ${c.value} w${c.startWeek}-${c.endWeek}`;
+      const store = c.store || 'ALL';
+      li.textContent = `${c.type} ${c.value} w${c.startWeek}-${c.endWeek} (${store})`;
       const del = document.createElement('button');
       del.textContent = 'X';
       del.addEventListener('click', async () => {
@@ -87,6 +90,14 @@ function createRow(item, couponsMap) {
   end.max = 52;
   end.className = 'week';
 
+  const storeSelect = document.createElement('select');
+  ['ALL', ...STORES].forEach(s => {
+    const opt = document.createElement('option');
+    opt.value = s;
+    opt.textContent = s;
+    storeSelect.appendChild(opt);
+  });
+
   const btn = document.createElement('button');
   btn.textContent = 'Submit';
 
@@ -113,14 +124,22 @@ function createRow(item, couponsMap) {
     } else {
       return;
     }
+    const store = storeSelect.value || 'ALL';
     if (!couponsMap[item.name]) couponsMap[item.name] = [];
-    couponsMap[item.name].push({ type, value, startWeek: sWeek, endWeek: eWeek });
+    couponsMap[item.name].push({
+      type,
+      value,
+      startWeek: sWeek,
+      endWeek: eWeek,
+      store
+    });
     await saveCoupons(couponsMap);
     pct.value = '';
     off.value = '';
     fixed.value = '';
     start.value = '';
     end.value = '';
+    storeSelect.value = 'ALL';
     refresh();
   });
 
@@ -133,6 +152,8 @@ function createRow(item, couponsMap) {
   div.appendChild(start);
   div.appendChild(document.createTextNode(' '));
   div.appendChild(end);
+  div.appendChild(document.createTextNode(' '));
+  div.appendChild(storeSelect);
   div.appendChild(document.createTextNode(' '));
   div.appendChild(btn);
   div.appendChild(ul);

--- a/scrapeResults.js
+++ b/scrapeResults.js
@@ -18,9 +18,12 @@ function getCurrentWeek() {
   return Math.ceil(((today - start) / 86400000 + start.getDay() + 1) / 7);
 }
 
-function applyCoupon(prod, coupons, week) {
+function applyCoupon(prod, coupons, week, store) {
   const coupon = (coupons || []).find(
-    c => week >= c.startWeek && week <= c.endWeek
+    c =>
+      week >= c.startWeek &&
+      week <= c.endWeek &&
+      (!c.store || c.store === 'ALL' || c.store === store)
   );
   if (!coupon || prod.priceNumber == null) return { ...prod };
   let price = prod.priceNumber;
@@ -91,7 +94,7 @@ title.textContent = `${item} - ${store}`;
 
 Promise.all([loadProducts(item, store), loadCoupons()]).then(([products, coupons]) => {
   const week = getCurrentWeek();
-  const adjusted = products.map(p => applyCoupon(p, coupons[item], week));
+  const adjusted = products.map(p => applyCoupon(p, coupons[item], week, store));
   const filtered = adjusted.filter(p => nameMatchesProduct(p.name, item));
   if (filtered.length === 0) {
     container.textContent = 'No products found.';


### PR DESCRIPTION
## Summary
- allow specifying a store (or ALL) when creating coupons
- display the selected store in the coupon list
- restrict coupon application in results to the chosen store
- add dropdown styling

## Testing
- `node --check coupon.js`
- `node --check scrapeResults.js`


------
https://chatgpt.com/codex/tasks/task_e_6852aefeba708329bbbebf1f0a891b50