### PR TITLE
Improve popup window layout

### DIFF
--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -250,16 +250,20 @@ async function refreshItems() {
 
 function resizeWindowToContent() {
   try {
-    const width = Math.min(
-      screen.availWidth,
-      document.documentElement.scrollWidth + 20
-    );
-    const height = Math.min(
-      screen.availHeight,
-      document.documentElement.scrollHeight + 20
-    );
-    chrome.windows.getCurrent(win => {
-      chrome.windows.update(win.id, { width, height });
+    chrome.storage.local.get('priceCheckerBounds', data => {
+      const b = data.priceCheckerBounds;
+      let width = screen.availWidth;
+      let left = 0;
+      if (b) {
+        width = Math.max(200, screen.availWidth - (b.left + b.width));
+        left = b.left + b.width;
+      }
+      const height = screen.availHeight;
+      chrome.windows.getCurrent(win => {
+        const opts = { width, height };
+        if (b) opts.left = left;
+        chrome.windows.update(win.id, opts);
+      });
     });
   } catch (e) {
     // ignore if chrome APIs are unavailable

--- a/item.js
+++ b/item.js
@@ -1,5 +1,6 @@
 import { loadJSON } from './utils/dataLoader.js';
 import { initUomTable } from './utils/uomConverter.js';
+import { openOverPriceChecker } from './utils/windowPlacement.js';
 
 const STORE_SELECTION_PATH = 'Required for grocery app/store_selection_stopandshop.json';
 const STORE_SELECTION_KEY = 'storeSelections';
@@ -118,7 +119,7 @@ async function init() {
         `scrapeResults.html?item=${encodeURIComponent(itemName)}&store=${encodeURIComponent(entry.store)}`
       );
       setTimeout(() => {
-        chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+        openOverPriceChecker(url);
       }, 1000);
     });
     header.appendChild(scrapeBtn);

--- a/launcher.js
+++ b/launcher.js
@@ -1,6 +1,40 @@
+const PRICE_WIDTH = 400;
+
 function openWindow(path) {
   const url = chrome.runtime.getURL(path);
-  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+  chrome.windows.getCurrent(current => {
+    const screenWidth = screen.availWidth;
+    const screenHeight = screen.availHeight;
+    const baseLeft = current.left + current.width;
+    const options = { url, type: 'popup' };
+    if (path === 'popup.html') {
+      options.width = PRICE_WIDTH;
+      options.height = screenHeight;
+      options.left = baseLeft;
+      options.top = current.top;
+      chrome.windows.create(options, win => {
+        chrome.storage.local.set({
+          priceCheckerBounds: {
+            left: win.left,
+            top: win.top,
+            width: win.width,
+            height: win.height
+          }
+        });
+      });
+    } else if (path === 'inventoryTimeline.html') {
+      const remaining = Math.max(200, screenWidth - baseLeft - PRICE_WIDTH);
+      options.width = remaining;
+      options.height = screenHeight;
+      options.left = baseLeft + PRICE_WIDTH;
+      options.top = current.top;
+      chrome.windows.create(options);
+    } else {
+      options.width = 400;
+      options.height = 600;
+      chrome.windows.create(options);
+    }
+  });
 }
 
 document.getElementById('open-price-checker').addEventListener('click', () => {

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,7 @@
 import { loadJSON } from './utils/dataLoader.js';
 import { calculatePurchaseNeeds } from './utils/purchaseCalculator.js';
 import { initUomTable, convert } from './utils/uomConverter.js';
+import { openOverPriceChecker } from './utils/windowPlacement.js';
 
 const YEARLY_NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
 const STORE_SELECTION_PATH = 'Required for grocery app/store_selection_stopandshop.json';
@@ -144,7 +145,7 @@ async function init() {
       const url = chrome.runtime.getURL(
         `item.html?item=${encodeURIComponent(item.name)}`
       );
-      chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+      openOverPriceChecker(url);
     });
     li.appendChild(btn);
     const finalSpan = document.createElement('span');
@@ -188,6 +189,24 @@ async function init() {
 }
 
 init();
+
+function storeBounds() {
+  try {
+    chrome.windows.getCurrent(win => {
+      chrome.storage.local.set({
+        priceCheckerBounds: {
+          left: win.left,
+          top: win.top,
+          width: win.width,
+          height: win.height
+        }
+      });
+    });
+  } catch (_) {}
+}
+
+storeBounds();
+window.addEventListener('resize', storeBounds);
 
 // Listen for scraped data sent from content script
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -375,14 +394,14 @@ async function commitSelections() {
   chrome.storage.local.set({ lastCommitItems: commitItems });
 
   const url = chrome.runtime.getURL('shoppingList.html');
-  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+  openOverPriceChecker(url);
 }
 
 document.getElementById('commit').addEventListener('click', commitSelections);
 
 function openInventory() {
   const url = chrome.runtime.getURL('inventory.html');
-  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+  openOverPriceChecker(url);
 }
 
 document
@@ -391,7 +410,7 @@ document
 
 function openConsumption() {
   const url = chrome.runtime.getURL('consumed.html');
-  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+  openOverPriceChecker(url);
 }
 
 document
@@ -400,14 +419,14 @@ document
 
 function openAddItem() {
   const url = chrome.runtime.getURL("addItem.html");
-  chrome.windows.create({ url, type: "popup", width: 400, height: 600 });
+  openOverPriceChecker(url);
 }
 
 document.getElementById("addItem").addEventListener("click", openAddItem);
 
 function openRemoveItem() {
   const url = chrome.runtime.getURL('removeItem.html');
-  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+  openOverPriceChecker(url);
 }
 
 document
@@ -416,7 +435,7 @@ document
 
 function openCouponManager() {
   const url = chrome.runtime.getURL('coupon.html');
-  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+  openOverPriceChecker(url);
 }
 
 document

--- a/utils/windowPlacement.js
+++ b/utils/windowPlacement.js
@@ -1,0 +1,13 @@
+export function openOverPriceChecker(url, defaultWidth = 400, defaultHeight = 600) {
+  chrome.storage.local.get('priceCheckerBounds', data => {
+    const b = data.priceCheckerBounds;
+    const opts = { url, type: 'popup', width: defaultWidth, height: defaultHeight };
+    if (b) {
+      opts.left = b.left;
+      opts.top = b.top;
+      opts.width = b.width;
+      opts.height = b.height;
+    }
+    chrome.windows.create(opts);
+  });
+}


### PR DESCRIPTION
## Summary
- reserve a dedicated width for the price checker and position other windows next to it
- persist popup bounds and open subsequent windows over the same space
- scale inventory timeline to remaining width on screen
- provide helper for opening windows over the price checker

## Testing
- `node --check launcher.js`
- `node --check popup.js`
- `node --check item.js`
- `node --check inventoryTimeline.js`


------
https://chatgpt.com/codex/tasks/task_e_6852b3559e3c832996303f4cc82cb538