### PR TITLE
Add dynamic window layout support

### DIFF
--- a/item.js
+++ b/item.js
@@ -1,5 +1,6 @@
 import { loadJSON } from './utils/dataLoader.js';
 import { initUomTable } from './utils/uomConverter.js';
+import { openInPriceCheckerArea } from './utils/windowLayout.js';
 
 const STORE_SELECTION_PATH = 'Required for grocery app/store_selection_stopandshop.json';
 const STORE_SELECTION_KEY = 'storeSelections';
@@ -118,7 +119,7 @@ async function init() {
         `scrapeResults.html?item=${encodeURIComponent(itemName)}&store=${encodeURIComponent(entry.store)}`
       );
       setTimeout(() => {
-        chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+        openInPriceCheckerArea(url, 600);
       }, 1000);
     });
     header.appendChild(scrapeBtn);

--- a/launcher.html
+++ b/launcher.html
@@ -11,6 +11,6 @@
 <body>
   <button id="open-price-checker">Price Checker</button>
   <button id="open-inventory-timeline">Inventory Timeline</button>
-  <script src="launcher.js"></script>
+  <script type="module" src="launcher.js"></script>
 </body>
 </html>

--- a/launcher.js
+++ b/launcher.js
@@ -1,12 +1,16 @@
-function openWindow(path) {
-  const url = chrome.runtime.getURL(path);
-  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
-}
+import {
+  openPriceChecker,
+  openInventoryTimeline
+} from './utils/windowLayout.js';
 
 document.getElementById('open-price-checker').addEventListener('click', () => {
-  openWindow('popup.html');
+  const url = chrome.runtime.getURL('popup.html');
+  openPriceChecker(url);
 });
 
-document.getElementById('open-inventory-timeline').addEventListener('click', () => {
-  openWindow('inventoryTimeline.html');
-});
+document
+  .getElementById('open-inventory-timeline')
+  .addEventListener('click', () => {
+    const url = chrome.runtime.getURL('inventoryTimeline.html');
+    openInventoryTimeline(url);
+  });

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,7 @@
 import { loadJSON } from './utils/dataLoader.js';
 import { calculatePurchaseNeeds } from './utils/purchaseCalculator.js';
 import { initUomTable, convert } from './utils/uomConverter.js';
+import { openInPriceCheckerArea } from './utils/windowLayout.js';
 
 const YEARLY_NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
 const STORE_SELECTION_PATH = 'Required for grocery app/store_selection_stopandshop.json';
@@ -144,7 +145,7 @@ async function init() {
       const url = chrome.runtime.getURL(
         `item.html?item=${encodeURIComponent(item.name)}`
       );
-      chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+      openInPriceCheckerArea(url, 600);
     });
     li.appendChild(btn);
     const finalSpan = document.createElement('span');
@@ -375,14 +376,14 @@ async function commitSelections() {
   chrome.storage.local.set({ lastCommitItems: commitItems });
 
   const url = chrome.runtime.getURL('shoppingList.html');
-  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+  openInPriceCheckerArea(url, 600);
 }
 
 document.getElementById('commit').addEventListener('click', commitSelections);
 
 function openInventory() {
   const url = chrome.runtime.getURL('inventory.html');
-  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+  openInPriceCheckerArea(url, 600);
 }
 
 document
@@ -391,7 +392,7 @@ document
 
 function openConsumption() {
   const url = chrome.runtime.getURL('consumed.html');
-  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+  openInPriceCheckerArea(url, 600);
 }
 
 document
@@ -400,14 +401,14 @@ document
 
 function openAddItem() {
   const url = chrome.runtime.getURL("addItem.html");
-  chrome.windows.create({ url, type: "popup", width: 400, height: 600 });
+  openInPriceCheckerArea(url, 600);
 }
 
 document.getElementById("addItem").addEventListener("click", openAddItem);
 
 function openRemoveItem() {
   const url = chrome.runtime.getURL('removeItem.html');
-  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+  openInPriceCheckerArea(url, 600);
 }
 
 document
@@ -416,7 +417,7 @@ document
 
 function openCouponManager() {
   const url = chrome.runtime.getURL('coupon.html');
-  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+  openInPriceCheckerArea(url, 600);
 }
 
 document

--- a/shoppingList.js
+++ b/shoppingList.js
@@ -1,3 +1,5 @@
+import { openInPriceCheckerArea } from './utils/windowLayout.js';
+
 function loadCommitItems() {
   return new Promise(resolve => {
     chrome.storage.local.get('lastCommitItems', data => {
@@ -78,7 +80,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           const btn = document.createElement('button');
           btn.textContent = 'View';
           btn.addEventListener('click', () => {
-            chrome.windows.create({ url: it.product.link, type: 'popup', width: 800, height: 800 });
+            openInPriceCheckerArea(it.product.link, 800);
           });
           li.appendChild(btn);
         }

--- a/utils/windowLayout.js
+++ b/utils/windowLayout.js
@@ -1,0 +1,86 @@
+export const PRICE_CHECKER_WIDTH = 400;
+
+export async function computeLayout() {
+  const mainWin = await chrome.windows.getCurrent({ populate: false });
+  const displays = await new Promise(resolve => {
+    chrome.system.display.getInfo(info => resolve(info));
+  });
+
+  let display = displays.find(d => {
+    const b = d.bounds;
+    return (
+      mainWin.left >= b.left &&
+      mainWin.left < b.left + b.width &&
+      mainWin.top >= b.top &&
+      mainWin.top < b.top + b.height
+    );
+  });
+  if (!display) display = displays[0];
+
+  const total = display.workArea || display.bounds;
+  const priceCheckerLeft = mainWin.left + mainWin.width;
+  const availableWidth = total.width - (priceCheckerLeft - total.left);
+  const inventoryWidth = Math.max(0, availableWidth - PRICE_CHECKER_WIDTH);
+
+  const layout = {
+    priceCheckerLeft,
+    inventoryLeft: priceCheckerLeft + PRICE_CHECKER_WIDTH,
+    inventoryWidth,
+    totalTop: total.top,
+    availableHeight: total.height,
+    lastPopupTop: 0
+  };
+  await chrome.storage.local.set({ windowLayout: layout });
+  return layout;
+}
+
+export async function getLayout() {
+  return new Promise(resolve => {
+    chrome.storage.local.get('windowLayout', data => {
+      if (data.windowLayout) {
+        resolve(data.windowLayout);
+      } else {
+        computeLayout().then(resolve);
+      }
+    });
+  });
+}
+
+export async function openPriceChecker(url) {
+  const layout = await computeLayout();
+  return chrome.windows.create({
+    url,
+    type: 'popup',
+    top: layout.totalTop,
+    left: layout.priceCheckerLeft,
+    width: PRICE_CHECKER_WIDTH,
+    height: layout.availableHeight
+  });
+}
+
+export async function openInventoryTimeline(url) {
+  const layout = await getLayout();
+  return chrome.windows.create({
+    url,
+    type: 'popup',
+    top: layout.totalTop,
+    left: layout.inventoryLeft,
+    width: layout.inventoryWidth,
+    height: layout.availableHeight
+  });
+}
+
+export async function openInPriceCheckerArea(url, height = 600) {
+  const layout = await getLayout();
+  const top = layout.lastPopupTop || 0;
+  const newTop = (top + 60) % layout.availableHeight;
+  await chrome.storage.local.set({ windowLayout: { ...layout, lastPopupTop: newTop } });
+  return chrome.windows.create({
+    url,
+    type: 'popup',
+    top: layout.totalTop + top,
+    left: layout.priceCheckerLeft,
+    width: PRICE_CHECKER_WIDTH,
+    height
+  });
+}


### PR DESCRIPTION
## Summary
- reserve space next to the main Chrome window for extension popups
- open Price Checker and Inventory Timeline in that reserved space
- cascade additional popups within the Price Checker area

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6852b978ce8083298e0fa1b1b0876ff6