### PR TITLE
Add backup import/export feature

### DIFF
--- a/backup.html
+++ b/backup.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Backup</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 300px; }
+    button { width: 100%; margin: 5px 0; }
+  </style>
+</head>
+<body>
+  <h1>Backup</h1>
+  <button id="exportBtn">Export</button>
+  <button id="importBtn">Import</button>
+  <input id="importFile" type="file" accept=".txt" style="display:none">
+  <script src="backup.js"></script>
+</body>
+</html>

--- a/backup.js
+++ b/backup.js
@@ -1,0 +1,38 @@
+function exportData() {
+  chrome.storage.local.get(null, data => {
+    const json = JSON.stringify(data, null, 2);
+    const blob = new Blob([json], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'grocery_backup.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+}
+
+function importFromText(text) {
+  try {
+    const data = JSON.parse(text);
+    chrome.storage.local.set(data, () => {
+      alert('Import complete');
+    });
+  } catch (e) {
+    alert('Invalid file');
+  }
+}
+
+function triggerImport() {
+  document.getElementById('importFile').click();
+}
+
+document.getElementById('exportBtn').addEventListener('click', exportData);
+document.getElementById('importBtn').addEventListener('click', triggerImport);
+
+document.getElementById('importFile').addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => importFromText(reader.result);
+  reader.readAsText(file);
+});

--- a/popup.html
+++ b/popup.html
@@ -31,6 +31,7 @@
       <button id="addItem">Add Item</button>
       <button id="removeItem">Remove Item</button>
       <button id="couponBtn">Coupons</button>
+      <button id="backupBtn">💾</button>
     </div>
   </div>
   <ul id="items"></ul>

--- a/popup.js
+++ b/popup.js
@@ -422,3 +422,12 @@ function openCouponManager() {
 document
   .getElementById('couponBtn')
   .addEventListener('click', openCouponManager);
+
+function openBackupManager() {
+  const url = chrome.runtime.getURL('backup.html');
+  chrome.windows.create({ url, type: 'popup', width: 400, height: 400 });
+}
+
+document
+  .getElementById('backupBtn')
+  .addEventListener('click', openBackupManager);


### PR DESCRIPTION
## Summary
- add Backup page with export/import buttons
- create JS logic to export and import data via chrome.storage
- add floppy disk button on main popup to open Backup window

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852c0afd9a4832999b6294e06132fa4