### PR TITLE
Add item categories and category-based sorting

### DIFF
--- a/GroceryInventory/extension/data/yearly_needs_with_manual_flags.json
+++ b/GroceryInventory/extension/data/yearly_needs_with_manual_flags.json
@@ -3,882 +3,1029 @@
     "name": "Air Fryer Vegetables Seasoned Frozen Foods",
     "total_needed_year": 52.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Bagels 6 count Bakery & Bread",
     "total_needed_year": 186.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Bags Freezer",
     "total_needed_year": 936.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Bags Quart",
     "total_needed_year": 100.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Kraft Macaroni & Cheese Original Flavor Packaged Meals",
     "total_needed_year": 30.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Minute Rice White Side Dishes",
     "total_needed_year": 26.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Cream of Wheat Instant Maple Brown Sugar Breakfast Cereals",
     "total_needed_year": 60.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Bread Sandwich Bakery & Bread",
     "total_needed_year": 312.0,
     "home_unit": "slice",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Pedigree DentaStix  Pet Supplies",
     "total_needed_year": 730.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pet"
   },
   {
     "name": "Cilantro  Produce",
     "total_needed_year": 3.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Produce"
   },
   {
     "name": "Brown Sugar  Baking & Cooking",
     "total_needed_year": 96.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Bob Evans Macaroni & Cheese  Packaged Meals",
     "total_needed_year": 52.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Cheese Shredded Cheddar Dairy",
     "total_needed_year": 208.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Purell Hand Sanitizer  Health & Beauty",
     "total_needed_year": 216.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Cheese White Sharp, Shredded Dairy",
     "total_needed_year": 144.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Beef Strip Steak Meat",
     "total_needed_year": 12.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Cottage Cheese Small Curd Dairy",
     "total_needed_year": 576.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Flour  Baking & Cooking",
     "total_needed_year": 20.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Bell Peppers  Produce",
     "total_needed_year": 24.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Produce"
   },
   {
     "name": "Garlic  Produce",
     "total_needed_year": 3.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Produce"
   },
   {
     "name": "Ginger  Produce",
     "total_needed_year": 3.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Produce"
   },
   {
     "name": "Cheese Muenster, Sliced Dairy",
     "total_needed_year": 296.0,
     "home_unit": "slices",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Heavy Cream  Dairy",
     "total_needed_year": 6.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Cheese String Dairy",
     "total_needed_year": 624.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Ground Beef Angus Sirloin Meat",
     "total_needed_year": 24.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Kale  Produce",
     "total_needed_year": 2.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Produce"
   },
   {
     "name": "Lime Juice  Beverages",
     "total_needed_year": 30.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Milk Gallon 1 Dairy",
     "total_needed_year": 52.0,
     "home_unit": "gallon",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Mushrooms Shiitake Produce",
     "total_needed_year": 360.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Imitation Crab  Seafood",
     "total_needed_year": 728.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Paper Bowl 20 oz",
     "total_needed_year": 432.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Paper Plate Everyday 10.06",
     "total_needed_year": 750.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Paper Plate Everyday 6.87",
     "total_needed_year": 768.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Potatoes Baby Produce",
     "total_needed_year": 72.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Pet Treats Pill Pockets Pet Supplies",
     "total_needed_year": 730.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pet"
   },
   {
     "name": "Sausage Sweet Meat",
     "total_needed_year": 288.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Potatoes Red Produce",
     "total_needed_year": 240.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Potatoes Russet Produce",
     "total_needed_year": 512.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Potatoes Yams Produce",
     "total_needed_year": 48.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Pretzel Frozen Frozen Foods",
     "total_needed_year": 156.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Sugar Snap Peas  Produce",
     "total_needed_year": 90.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Sriracha Hot Chili Sauce,  Condiments Sauces",
     "total_needed_year": 17.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Birds Eye Skillet Meals  Frozen Foods",
     "total_needed_year": 26.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Tortillas  Bakery & Bread",
     "total_needed_year": 60.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Aleia's Bread Crumbs Italian, Gluten Free Baking Supplies",
     "total_needed_year": 156.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Argo Corn Starch 100 Pure Baking Supplies",
     "total_needed_year": 32.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Arm & Hammer Baking Soda Pure Baking Supplies",
     "total_needed_year": 64.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Barilla Pasta Fettuccine Pasta",
     "total_needed_year": 16.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Pantry"
   },
   {
     "name": "Bertolli Vinegar Balsamic Vinegars",
     "total_needed_year": 8.5,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Betty Crocker Cookie Mix Snickerdoodle Baking Supplies",
     "total_needed_year": 12.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Pantry"
   },
   {
     "name": "Foxy Romaine Hearts  Fresh Produce",
     "total_needed_year": 48.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Botticelli Pasta Sauce Traditional Premium Pasta Sauce",
     "total_needed_year": 24.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Bounty Paper Towels",
     "total_needed_year": 180.0,
     "home_unit": "sheets",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Bragg Apple Cider Vinegar Organic Vinegars",
     "total_needed_year": 16.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Bumble Bee Canned Tuna Albacore Light Canned Seafood",
     "total_needed_year": 12.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Pantry"
   },
   {
     "name": "Cabot Butter Salted Dairy",
     "total_needed_year": 192.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Campbell's Soup Chicken Noodle Soup",
     "total_needed_year": 12.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Cascade Dishwasher Detergent Platinum",
     "total_needed_year": 186.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Cheerios Cereal Strawberry Banana Breakfast Cereals",
     "total_needed_year": 90.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Chex Cereal Corn Breakfast Cereals",
     "total_needed_year": 72.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Chips Ahoy Cookies Chocolate Chip Snacks",
     "total_needed_year": 946.4,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Chosen Foods Oil Organic Avocado, Coconut & Safflower Cooking Oils",
     "total_needed_year": 16.9,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Coffee-mate Iced Coffee French Vanilla Beverages",
     "total_needed_year": 264.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Heinz Ketchup Tomato Condiments",
     "total_needed_year": 202.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Philadelphia Cream Cheese Spread Original Dairy",
     "total_needed_year": 96.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Store brand Cheddar Cheese Medium Sliced,  Dairy",
     "total_needed_year": 370.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Daisy Sour Cream  Dairy",
     "total_needed_year": 56.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Dawn Dishwand Ultra Soap Dispensing Cleaning Supplies",
     "total_needed_year": 1.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Dawn Dishwashing Liquid Platinum Refreshing Rain Cleaning Supplies",
     "total_needed_year": 858.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Store brand Parmesan Cheese Grated,  Dairy",
     "total_needed_year": 48.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Diamond of California Pecans Finely Diced Baking Nuts",
     "total_needed_year": 6.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Domino Powdered Sugar Premium Cane Baking Supplies",
     "total_needed_year": 32.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Filippo Berio Olive Oil Extra Light Cooking Oils",
     "total_needed_year": 50.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Stouffer's Mac N Cheese Bites  Frozen Foods",
     "total_needed_year": 84.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Frank's RedHot Sauce Original Condiments Sauces",
     "total_needed_year": 23.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "French's Mustard Classic Yellow Condiments",
     "total_needed_year": 10.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Frenches Fried Onions Crispy  Condiments",
     "total_needed_year": 12.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Glad Trash Bags 13 Gallon, forceflex, fresh clean Cleaning",
     "total_needed_year": 120.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Broccoli Frozen Frozen Foods",
     "total_needed_year": 52.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Green Mountain Coffee K-Cup Pods Nantucket Blend, Medium Roast Coffee & Tea",
     "total_needed_year": 365.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Beverages"
   },
   {
     "name": "Grey Poupon Mustard Dijon Condiments",
     "total_needed_year": 32.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Gulden's Mustard Spicy Brown Condiments",
     "total_needed_year": 12.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Hamburger Helper Pasta Meal Deluxe Beef Stroganoff Packaged Meals",
     "total_needed_year": 13.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Hamburger Helper Pasta Meal Potatoes Stroganoff Packaged Meals",
     "total_needed_year": 13.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Pantry"
   },
   {
     "name": "Hass Avocados 4 ct Fresh Produce",
     "total_needed_year": 12.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Ice Cream  Frozen Foods",
     "total_needed_year": 52.0,
     "home_unit": "pint",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Hellmann's Mayonnaise Real Condiments Spreads",
     "total_needed_year": 180.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Hellmann's Mayonnaise Real Squeeze Bottle Condiments",
     "total_needed_year": 80.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Hellmann's Mayonnaise Spicy Condiments",
     "total_needed_year": 11.5,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Hershey's Cocoa  Baking Supplies",
     "total_needed_year": 4.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Hershey's Syrup Genuine Chocolate Flavor Condiments Syrups",
     "total_needed_year": 288.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Hormel Canned Chicken Breast  Canned Meats",
     "total_needed_year": 1.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Del Monte Mixed Vegetables  Canned",
     "total_needed_year": 24.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Produce"
   },
   {
     "name": "I Can't Believe It's Not Butter! Butter Spray Original Spreads",
     "total_needed_year": 96.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "I Can't Believe It's Not Butter! Butter Substitute  Spreads",
     "total_needed_year": 540.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Idahoan Mashed Potatoes Loaded Baked Side Dishes",
     "total_needed_year": 17.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Other"
   },
   {
     "name": "Jif Peanut Butter Creamy Spreads",
     "total_needed_year": 160.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Ken's Steak House Blue Cheese Dressing Chunky Condiments Dressings",
     "total_needed_year": 32.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Kerrygold Butter Pure Irish, Unsalted Dairy",
     "total_needed_year": 32.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Kikkoman Marinade & Sauce Teriyaki Condiments Sauces",
     "total_needed_year": 15.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Beef Steak Tips Meat",
     "total_needed_year": 12.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Kozy Shack Rice Pudding Original Recipe, Gluten Free Dairy",
     "total_needed_year": 312.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Lindy Italian Ice  Frozen Foods",
     "total_needed_year": 552.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Krusteaz Muffin Mix Cranberry Baking Supplies",
     "total_needed_year": 1.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Lea & Perrins Worcestershire Sauce The Original Condiments Sauces",
     "total_needed_year": 5.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Libbys Pumpkin 100 pure Canned",
     "total_needed_year": 15.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Store Brand Mushrooms Stems and Pieces  Canned",
     "total_needed_year": 192.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "McCormick Cream of Tartar  Baking Supplies",
     "total_needed_year": 1.5,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Milk-Bone Flavor Snacks  Pet Supplies",
     "total_needed_year": 469.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Bread Sour Dough Bakery & Bread",
     "total_needed_year": 832.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Monster Energy Drink  Beverages",
     "total_needed_year": 365.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Beverages"
   },
   {
     "name": "Mott's Applesauce  Snacks Fruits",
     "total_needed_year": 208.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Mrs. Butterworth's Syrup Extra Buttery Condiments Syrups",
     "total_needed_year": 48.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Mt. Olive Pickles Bread & Butter Chips Condiments Pickles",
     "total_needed_year": 12.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Nature's Promise Garlic Minced Cooking Ingredients",
     "total_needed_year": 64.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Nestle Nesquik Chocolate Beverage Mixes",
     "total_needed_year": 456.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Beverages"
   },
   {
     "name": "Nudges Grillers  Pet Supplies",
     "total_needed_year": 96.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pet"
   },
   {
     "name": "Ocean Spray Cranberry Sauce Jellied Canned Fruits",
     "total_needed_year": 28.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Pace Salsa Chunky Mild Condiments",
     "total_needed_year": 288.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "College Inn Beef Stock  Broth & Bouillon",
     "total_needed_year": 64.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Perdue Chicken Breast Cutlets  Meat & Poultry",
     "total_needed_year": 144.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Hormel Corned Beef Hash Mary Kitchen Canned Meats",
     "total_needed_year": 7.5,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Progresso Soup Traditional Chickarina Soup",
     "total_needed_year": 1.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Other"
   },
   {
     "name": "Progresso Soup Traditional Chicken & Wild Rice Soup",
     "total_needed_year": 2.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Planters Peanuts Cocktail Snacks",
     "total_needed_year": 16.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Quaker Instant Oatmeal Strawberries n Cream Breakfast Cereals",
     "total_needed_year": 56.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Spectrum Sesame Oil Organic Toasted Cooking Oils",
     "total_needed_year": 16.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Spice Islands Almond Extract Pure Baking Supplies",
     "total_needed_year": 2.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Store brand Apple Cider Vinegar  Vinegars",
     "total_needed_year": 64.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Store brand Baking Powder Double Acting,  Baking Supplies",
     "total_needed_year": 16.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Tuttorosso Tomatoes Diced, Canned Canned Goods",
     "total_needed_year": 6.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "College Inn Chicken Broth  Broth & Bouillon",
     "total_needed_year": 64.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Kikkoman Soy Sauce Less Sodium Condiments Sauces",
     "total_needed_year": 30.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Store brand Parmesan Cheese Shredded Dairy",
     "total_needed_year": 36.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Store brand Ricotta Cheese Brand  Sargento Dairy",
     "total_needed_year": 192.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Store brand Spinach Washed Fresh Produce",
     "total_needed_year": 96.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Store brand Vanilla Extract Pure Baking Supplies",
     "total_needed_year": 2.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Store brand Vinegar White Vinegars",
     "total_needed_year": 256.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Frozen Vegetables Peas and Corn Frozen Foods",
     "total_needed_year": 4.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Sweet Baby Ray's Barbecue Sauce  Condiments Sauces",
     "total_needed_year": 40.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Sweet Baby Ray's Sauce Sweet Teriyaki Condiments Sauces",
     "total_needed_year": 9.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Taste of Inspirations Gnocchi Potato, Made in Italy Pasta",
     "total_needed_year": 6.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Pantry"
   },
   {
     "name": "Tostitos Salsa Chunky Mild Snacks Condiments",
     "total_needed_year": 24.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Paper Bowl 10 oz",
     "total_needed_year": 210.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Wilton Candy Melts Light Cocoa Baking Supplies",
     "total_needed_year": 72.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Wish-Bone Dressing House Italian Condiments Dressings",
     "total_needed_year": 18.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Yoo-hoo Chocolate Drink",
     "total_needed_year": 320.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Beverages"
   }
 ]

--- a/Required for grocery app/yearly_needs_with_manual_flags.json
+++ b/Required for grocery app/yearly_needs_with_manual_flags.json
@@ -3,882 +3,1029 @@
     "name": "Air Fryer Vegetables Seasoned Frozen Foods",
     "total_needed_year": 52.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Bagels 6 count Bakery & Bread",
     "total_needed_year": 186.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Bags Freezer",
     "total_needed_year": 936.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Bags Quart",
     "total_needed_year": 100.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Kraft Macaroni & Cheese Original Flavor Packaged Meals",
     "total_needed_year": 30.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Minute Rice White Side Dishes",
     "total_needed_year": 26.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Cream of Wheat Instant Maple Brown Sugar Breakfast Cereals",
     "total_needed_year": 60.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Bread Sandwich Bakery & Bread",
     "total_needed_year": 312.0,
     "home_unit": "slice",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Pedigree DentaStix  Pet Supplies",
     "total_needed_year": 730.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pet"
   },
   {
     "name": "Cilantro  Produce",
     "total_needed_year": 3.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Produce"
   },
   {
     "name": "Brown Sugar  Baking & Cooking",
     "total_needed_year": 96.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Bob Evans Macaroni & Cheese  Packaged Meals",
     "total_needed_year": 52.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Cheese Shredded Cheddar Dairy",
     "total_needed_year": 208.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Purell Hand Sanitizer  Health & Beauty",
     "total_needed_year": 216.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Cheese White Sharp, Shredded Dairy",
     "total_needed_year": 144.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Beef Strip Steak Meat",
     "total_needed_year": 12.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Cottage Cheese Small Curd Dairy",
     "total_needed_year": 576.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Flour  Baking & Cooking",
     "total_needed_year": 20.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Bell Peppers  Produce",
     "total_needed_year": 24.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Produce"
   },
   {
     "name": "Garlic  Produce",
     "total_needed_year": 3.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Produce"
   },
   {
     "name": "Ginger  Produce",
     "total_needed_year": 3.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Produce"
   },
   {
     "name": "Cheese Muenster, Sliced Dairy",
     "total_needed_year": 296.0,
     "home_unit": "slices",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Heavy Cream  Dairy",
     "total_needed_year": 6.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Cheese String Dairy",
     "total_needed_year": 624.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Ground Beef Angus Sirloin Meat",
     "total_needed_year": 24.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Kale  Produce",
     "total_needed_year": 2.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Produce"
   },
   {
     "name": "Lime Juice  Beverages",
     "total_needed_year": 30.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Milk Gallon 1 Dairy",
     "total_needed_year": 52.0,
     "home_unit": "gallon",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Mushrooms Shiitake Produce",
     "total_needed_year": 360.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Imitation Crab  Seafood",
     "total_needed_year": 728.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Paper Bowl 20 oz",
     "total_needed_year": 432.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Paper Plate Everyday 10.06",
     "total_needed_year": 750.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Paper Plate Everyday 6.87",
     "total_needed_year": 768.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Potatoes Baby Produce",
     "total_needed_year": 72.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Pet Treats Pill Pockets Pet Supplies",
     "total_needed_year": 730.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pet"
   },
   {
     "name": "Sausage Sweet Meat",
     "total_needed_year": 288.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Potatoes Red Produce",
     "total_needed_year": 240.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Potatoes Russet Produce",
     "total_needed_year": 512.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Potatoes Yams Produce",
     "total_needed_year": 48.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Pretzel Frozen Frozen Foods",
     "total_needed_year": 156.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Sugar Snap Peas  Produce",
     "total_needed_year": 90.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Sriracha Hot Chili Sauce,  Condiments Sauces",
     "total_needed_year": 17.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Birds Eye Skillet Meals  Frozen Foods",
     "total_needed_year": 26.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Tortillas  Bakery & Bread",
     "total_needed_year": 60.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Aleia's Bread Crumbs Italian, Gluten Free Baking Supplies",
     "total_needed_year": 156.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Argo Corn Starch 100 Pure Baking Supplies",
     "total_needed_year": 32.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Arm & Hammer Baking Soda Pure Baking Supplies",
     "total_needed_year": 64.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Barilla Pasta Fettuccine Pasta",
     "total_needed_year": 16.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Pantry"
   },
   {
     "name": "Bertolli Vinegar Balsamic Vinegars",
     "total_needed_year": 8.5,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Betty Crocker Cookie Mix Snickerdoodle Baking Supplies",
     "total_needed_year": 12.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Pantry"
   },
   {
     "name": "Foxy Romaine Hearts  Fresh Produce",
     "total_needed_year": 48.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Botticelli Pasta Sauce Traditional Premium Pasta Sauce",
     "total_needed_year": 24.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Bounty Paper Towels",
     "total_needed_year": 180.0,
     "home_unit": "sheets",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Bragg Apple Cider Vinegar Organic Vinegars",
     "total_needed_year": 16.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Bumble Bee Canned Tuna Albacore Light Canned Seafood",
     "total_needed_year": 12.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Pantry"
   },
   {
     "name": "Cabot Butter Salted Dairy",
     "total_needed_year": 192.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Campbell's Soup Chicken Noodle Soup",
     "total_needed_year": 12.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Cascade Dishwasher Detergent Platinum",
     "total_needed_year": 186.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Cheerios Cereal Strawberry Banana Breakfast Cereals",
     "total_needed_year": 90.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Chex Cereal Corn Breakfast Cereals",
     "total_needed_year": 72.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Chips Ahoy Cookies Chocolate Chip Snacks",
     "total_needed_year": 946.4,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Chosen Foods Oil Organic Avocado, Coconut & Safflower Cooking Oils",
     "total_needed_year": 16.9,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Coffee-mate Iced Coffee French Vanilla Beverages",
     "total_needed_year": 264.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Heinz Ketchup Tomato Condiments",
     "total_needed_year": 202.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Philadelphia Cream Cheese Spread Original Dairy",
     "total_needed_year": 96.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Store brand Cheddar Cheese Medium Sliced,  Dairy",
     "total_needed_year": 370.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Daisy Sour Cream  Dairy",
     "total_needed_year": 56.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Dawn Dishwand Ultra Soap Dispensing Cleaning Supplies",
     "total_needed_year": 1.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Dawn Dishwashing Liquid Platinum Refreshing Rain Cleaning Supplies",
     "total_needed_year": 858.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Store brand Parmesan Cheese Grated,  Dairy",
     "total_needed_year": 48.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Diamond of California Pecans Finely Diced Baking Nuts",
     "total_needed_year": 6.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Domino Powdered Sugar Premium Cane Baking Supplies",
     "total_needed_year": 32.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Filippo Berio Olive Oil Extra Light Cooking Oils",
     "total_needed_year": 50.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Stouffer's Mac N Cheese Bites  Frozen Foods",
     "total_needed_year": 84.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Frank's RedHot Sauce Original Condiments Sauces",
     "total_needed_year": 23.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "French's Mustard Classic Yellow Condiments",
     "total_needed_year": 10.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Frenches Fried Onions Crispy  Condiments",
     "total_needed_year": 12.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Glad Trash Bags 13 Gallon, forceflex, fresh clean Cleaning",
     "total_needed_year": 120.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Broccoli Frozen Frozen Foods",
     "total_needed_year": 52.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Green Mountain Coffee K-Cup Pods Nantucket Blend, Medium Roast Coffee & Tea",
     "total_needed_year": 365.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Beverages"
   },
   {
     "name": "Grey Poupon Mustard Dijon Condiments",
     "total_needed_year": 32.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Gulden's Mustard Spicy Brown Condiments",
     "total_needed_year": 12.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Hamburger Helper Pasta Meal Deluxe Beef Stroganoff Packaged Meals",
     "total_needed_year": 13.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Hamburger Helper Pasta Meal Potatoes Stroganoff Packaged Meals",
     "total_needed_year": 13.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Pantry"
   },
   {
     "name": "Hass Avocados 4 ct Fresh Produce",
     "total_needed_year": 12.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Ice Cream  Frozen Foods",
     "total_needed_year": 52.0,
     "home_unit": "pint",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Hellmann's Mayonnaise Real Condiments Spreads",
     "total_needed_year": 180.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Hellmann's Mayonnaise Real Squeeze Bottle Condiments",
     "total_needed_year": 80.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Hellmann's Mayonnaise Spicy Condiments",
     "total_needed_year": 11.5,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Hershey's Cocoa  Baking Supplies",
     "total_needed_year": 4.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Hershey's Syrup Genuine Chocolate Flavor Condiments Syrups",
     "total_needed_year": 288.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Hormel Canned Chicken Breast  Canned Meats",
     "total_needed_year": 1.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Del Monte Mixed Vegetables  Canned",
     "total_needed_year": 24.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Produce"
   },
   {
     "name": "I Can't Believe It's Not Butter! Butter Spray Original Spreads",
     "total_needed_year": 96.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "I Can't Believe It's Not Butter! Butter Substitute  Spreads",
     "total_needed_year": 540.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Idahoan Mashed Potatoes Loaded Baked Side Dishes",
     "total_needed_year": 17.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Other"
   },
   {
     "name": "Jif Peanut Butter Creamy Spreads",
     "total_needed_year": 160.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Ken's Steak House Blue Cheese Dressing Chunky Condiments Dressings",
     "total_needed_year": 32.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Kerrygold Butter Pure Irish, Unsalted Dairy",
     "total_needed_year": 32.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Kikkoman Marinade & Sauce Teriyaki Condiments Sauces",
     "total_needed_year": 15.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Beef Steak Tips Meat",
     "total_needed_year": 12.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Kozy Shack Rice Pudding Original Recipe, Gluten Free Dairy",
     "total_needed_year": 312.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Lindy Italian Ice  Frozen Foods",
     "total_needed_year": 552.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Krusteaz Muffin Mix Cranberry Baking Supplies",
     "total_needed_year": 1.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Lea & Perrins Worcestershire Sauce The Original Condiments Sauces",
     "total_needed_year": 5.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Libbys Pumpkin 100 pure Canned",
     "total_needed_year": 15.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Store Brand Mushrooms Stems and Pieces  Canned",
     "total_needed_year": 192.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "McCormick Cream of Tartar  Baking Supplies",
     "total_needed_year": 1.5,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Milk-Bone Flavor Snacks  Pet Supplies",
     "total_needed_year": 469.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Bread Sour Dough Bakery & Bread",
     "total_needed_year": 832.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Other"
   },
   {
     "name": "Monster Energy Drink  Beverages",
     "total_needed_year": 365.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Beverages"
   },
   {
     "name": "Mott's Applesauce  Snacks Fruits",
     "total_needed_year": 208.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Mrs. Butterworth's Syrup Extra Buttery Condiments Syrups",
     "total_needed_year": 48.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Mt. Olive Pickles Bread & Butter Chips Condiments Pickles",
     "total_needed_year": 12.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Nature's Promise Garlic Minced Cooking Ingredients",
     "total_needed_year": 64.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Nestle Nesquik Chocolate Beverage Mixes",
     "total_needed_year": 456.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Beverages"
   },
   {
     "name": "Nudges Grillers  Pet Supplies",
     "total_needed_year": 96.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pet"
   },
   {
     "name": "Ocean Spray Cranberry Sauce Jellied Canned Fruits",
     "total_needed_year": 28.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Pace Salsa Chunky Mild Condiments",
     "total_needed_year": 288.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "College Inn Beef Stock  Broth & Bouillon",
     "total_needed_year": 64.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Perdue Chicken Breast Cutlets  Meat & Poultry",
     "total_needed_year": 144.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Hormel Corned Beef Hash Mary Kitchen Canned Meats",
     "total_needed_year": 7.5,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Progresso Soup Traditional Chickarina Soup",
     "total_needed_year": 1.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Other"
   },
   {
     "name": "Progresso Soup Traditional Chicken & Wild Rice Soup",
     "total_needed_year": 2.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Planters Peanuts Cocktail Snacks",
     "total_needed_year": 16.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Quaker Instant Oatmeal Strawberries n Cream Breakfast Cereals",
     "total_needed_year": 56.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Spectrum Sesame Oil Organic Toasted Cooking Oils",
     "total_needed_year": 16.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Spice Islands Almond Extract Pure Baking Supplies",
     "total_needed_year": 2.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Store brand Apple Cider Vinegar  Vinegars",
     "total_needed_year": 64.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Store brand Baking Powder Double Acting,  Baking Supplies",
     "total_needed_year": 16.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Tuttorosso Tomatoes Diced, Canned Canned Goods",
     "total_needed_year": 6.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "College Inn Chicken Broth  Broth & Bouillon",
     "total_needed_year": 64.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Freezer"
   },
   {
     "name": "Kikkoman Soy Sauce Less Sodium Condiments Sauces",
     "total_needed_year": 30.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Store brand Parmesan Cheese Shredded Dairy",
     "total_needed_year": 36.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Store brand Ricotta Cheese Brand  Sargento Dairy",
     "total_needed_year": 192.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Refrigerator"
   },
   {
     "name": "Store brand Spinach Washed Fresh Produce",
     "total_needed_year": 96.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Produce"
   },
   {
     "name": "Store brand Vanilla Extract Pure Baking Supplies",
     "total_needed_year": 2.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Store brand Vinegar White Vinegars",
     "total_needed_year": 256.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Frozen Vegetables Peas and Corn Frozen Foods",
     "total_needed_year": 4.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Freezer"
   },
   {
     "name": "Sweet Baby Ray's Barbecue Sauce  Condiments Sauces",
     "total_needed_year": 40.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Sweet Baby Ray's Sauce Sweet Teriyaki Condiments Sauces",
     "total_needed_year": 9.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Taste of Inspirations Gnocchi Potato, Made in Italy Pasta",
     "total_needed_year": 6.0,
     "home_unit": "each",
-    "treat_as_whole_unit": true
+    "treat_as_whole_unit": true,
+    "category": "Pantry"
   },
   {
     "name": "Tostitos Salsa Chunky Mild Snacks Condiments",
     "total_needed_year": 24.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Paper Bowl 10 oz",
     "total_needed_year": 210.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Household"
   },
   {
     "name": "Wilton Candy Melts Light Cocoa Baking Supplies",
     "total_needed_year": 72.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Wish-Bone Dressing House Italian Condiments Dressings",
     "total_needed_year": 18.0,
     "home_unit": "oz",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Pantry"
   },
   {
     "name": "Yoo-hoo Chocolate Drink",
     "total_needed_year": 320.0,
     "home_unit": "each",
-    "treat_as_whole_unit": false
+    "treat_as_whole_unit": false,
+    "category": "Beverages"
   }
 ]

--- a/addItem.html
+++ b/addItem.html
@@ -35,6 +35,9 @@
   <div class="field">
     <label>Week <input id="week" type="number" min="1" max="52"></label>
   </div>
+  <div class="field">
+    <label>Category <input id="category" type="text"></label>
+  </div>
   <button id="commit">Commit</button>
   <script type="module" src="addItem.js"></script>
 </body>

--- a/addItem.js
+++ b/addItem.js
@@ -90,6 +90,7 @@ async function commit() {
   const shelf = parseFloat(document.getElementById('shelf').value) || 12;
   const stockAmt = parseFloat(document.getElementById('stock').value) || 0;
   const week = parseInt(document.getElementById('week').value, 10) || 1;
+  const category = document.getElementById('category').value.trim();
 
   const [needs, consumption, stock, expiration, consumed, storeSelections, purchases] = await Promise.all([
     loadNeeds(),
@@ -105,7 +106,8 @@ async function commit() {
     name,
     total_needed_year: yearly,
     home_unit: unit,
-    treat_as_whole_unit: whole
+    treat_as_whole_unit: whole,
+    category
   });
   consumption.push({ name, monthly_consumption: monthly, unit });
   stock.push({ name, amount: stockAmt, unit });

--- a/consumed.js
+++ b/consumed.js
@@ -1,4 +1,5 @@
 import { loadJSON } from './utils/dataLoader.js';
+import { sortItemsByCategory } from './utils/sortByCategory.js';
 
 const NEEDS_KEY = 'yearlyNeeds';
 
@@ -162,9 +163,10 @@ async function init() {
     loadNeeds(),
     loadOverrides()
   ]);
+  const sortedNeeds = sortItemsByCategory(needs);
   const map = new Map(consumed.map(i => [i.name, i]));
   // ensure all needs exist
-  needs.forEach(n => {
+  sortedNeeds.forEach(n => {
     if (!map.has(n.name)) {
       const it = { name: n.name, amount: 0, unit: n.home_unit };
       map.set(n.name, it);
@@ -172,7 +174,7 @@ async function init() {
     }
   });
   // render in needs order
-  needs.forEach(n => {
+  sortedNeeds.forEach(n => {
     const item = map.get(n.name);
     const weekly = n.total_needed_year ? n.total_needed_year / 52 : 0;
     const row = createItemRow(item, map, history, overrides, weekly);

--- a/coupon.js
+++ b/coupon.js
@@ -1,4 +1,5 @@
 import { loadJSON } from './utils/dataLoader.js';
+import { sortItemsByCategory } from './utils/sortByCategory.js';
 
 const NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
 
@@ -163,7 +164,8 @@ function createRow(item, couponsMap) {
 async function init() {
   const container = document.getElementById('coupons');
   const [needs, coupons] = await Promise.all([loadNeeds(), loadCoupons()]);
-  needs.forEach(n => {
+  const sortedNeeds = sortItemsByCategory(needs);
+  sortedNeeds.forEach(n => {
     const row = createRow(n, coupons);
     container.appendChild(row);
   });

--- a/expiration.js
+++ b/expiration.js
@@ -1,4 +1,5 @@
 import { loadJSON } from './utils/dataLoader.js';
+import { sortItemsByCategory } from './utils/sortByCategory.js';
 
 const NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
 const EXPIRATION_PATH = 'Required for grocery app/expiration_times_full.json';
@@ -71,9 +72,10 @@ function createRow(item, expMap, expArr) {
 
 async function init() {
   const [needs, expiration] = await Promise.all([loadNeeds(), loadExpiration()]);
+  const sortedNeeds = sortItemsByCategory(needs);
   const expMap = new Map(expiration.map(e => [e.name, e]));
   const container = document.getElementById('expirations');
-  needs.forEach(n => {
+  sortedNeeds.forEach(n => {
     const row = createRow(n, expMap, expiration);
     container.appendChild(row);
   });

--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -57,6 +57,17 @@ function loadArray(key, path) {
   });
 }
 
+function sortItemsByCategory(arr) {
+  return arr.slice().sort((a, b) => {
+    const catA = (a.category || '').toLowerCase();
+    const catB = (b.category || '').toLowerCase();
+    if (catA === catB) {
+      return a.name.localeCompare(b.name);
+    }
+    return catA.localeCompare(catB);
+  });
+}
+
 async function loadData() {
   const [needs, expiration, stock] = await Promise.all([
     loadArray('yearlyNeeds', 'Required for grocery app/yearly_needs_with_manual_flags.json'),
@@ -208,7 +219,8 @@ let gridContainer;
 
 async function fetchItems() {
   const data = await loadData();
-  const items = buildItemMap(data.needs, data.expiration, data.stock);
+  const sortedNeeds = sortItemsByCategory(data.needs);
+  const items = buildItemMap(sortedNeeds, data.expiration, data.stock);
   const [savedMap, overridesMap] = await Promise.all([
     loadPurchases(),
     loadOverrides()

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,7 @@
 import { loadJSON } from './utils/dataLoader.js';
 import { calculatePurchaseNeeds } from './utils/purchaseCalculator.js';
 import { initUomTable, convert } from './utils/uomConverter.js';
+import { sortItemsByCategory } from './utils/sortByCategory.js';
 
 const YEARLY_NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
 const STORE_SELECTION_PATH = 'Required for grocery app/store_selection_stopandshop.json';
@@ -113,6 +114,7 @@ async function init() {
   const { needs, selections, consumption, stock, expiration, consumed, purchases } =
     await getData();
   needsData = needs;
+  const sortedNeeds = sortItemsByCategory(needs);
   consumptionData = consumption;
   expirationData = expiration;
   stockData = stock;
@@ -132,7 +134,7 @@ async function init() {
   const stockMap = new Map(stock.map(i => [i.name, i]));
   const itemsContainer = document.getElementById('items');
 
-  needs.forEach(item => {
+  sortedNeeds.forEach(item => {
     const li = document.createElement('li');
     const info = purchaseMap.get(item.name);
     const needAmt = info ? Math.round(info.toBuy) : null;

--- a/removeItem.js
+++ b/removeItem.js
@@ -1,4 +1,5 @@
 import { loadJSON } from './utils/dataLoader.js';
+import { sortItemsByCategory } from './utils/sortByCategory.js';
 
 const YEARLY_NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
 const CONSUMPTION_PATH = 'Required for grocery app/monthly_consumption_table.json';
@@ -158,8 +159,9 @@ function createListItem(name) {
 
 async function init() {
   const items = await loadNeeds();
+  const sortedItems = sortItemsByCategory(items);
   const ul = document.getElementById('items');
-  items.forEach(it => {
+  sortedItems.forEach(it => {
     ul.appendChild(createListItem(it.name));
   });
 }

--- a/utils/sortByCategory.js
+++ b/utils/sortByCategory.js
@@ -1,0 +1,10 @@
+export function sortItemsByCategory(arr) {
+  return arr.slice().sort((a, b) => {
+    const catA = (a.category || '').toLowerCase();
+    const catB = (b.category || '').toLowerCase();
+    if (catA === catB) {
+      return a.name.localeCompare(b.name);
+    }
+    return catA.localeCompare(catB);
+  });
+}


### PR DESCRIPTION
## Summary
- add `sortItemsByCategory` utility
- include category input on add item form
- save category field when creating items
- guess categories for existing items
- sort lists across extension by category

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852cb2b174c8329a896f90936fa0499