### PR TITLE
Add category headers to lists

### DIFF
--- a/consumed.html
+++ b/consumed.html
@@ -11,6 +11,10 @@
     ul.history { list-style: none; padding-left: 20px; margin-top: 5px; }
     ul.history li { font-size: 0.9em; }
     ul.history button { margin-left: 5px; }
+    .category-header {
+      border-top: 1px solid #ccc;
+      margin-top: 10px;
+    }
   </style>
 </head>
 <body>

--- a/consumed.js
+++ b/consumed.js
@@ -1,5 +1,8 @@
 import { loadJSON } from './utils/dataLoader.js';
-import { sortItemsByCategory } from './utils/sortByCategory.js';
+import {
+  sortItemsByCategory,
+  renderItemsWithCategoryHeaders
+} from './utils/sortByCategory.js';
 
 const NEEDS_KEY = 'yearlyNeeds';
 
@@ -174,11 +177,10 @@ async function init() {
     }
   });
   // render in needs order
-  sortedNeeds.forEach(n => {
+  renderItemsWithCategoryHeaders(sortedNeeds, container, n => {
     const item = map.get(n.name);
     const weekly = n.total_needed_year ? n.total_needed_year / 52 : 0;
-    const row = createItemRow(item, map, history, overrides, weekly);
-    container.appendChild(row);
+    return createItemRow(item, map, history, overrides, weekly);
   });
   await saveConsumption(Array.from(map.values()));
   await saveOverrides(overrides);

--- a/coupon.html
+++ b/coupon.html
@@ -9,6 +9,10 @@
     input[type="number"] { width: 60px; }
     input.week { width: 50px; }
     select { width: 110px; }
+    .category-header {
+      border-top: 1px solid #ccc;
+      margin-top: 10px;
+    }
   </style>
 </head>
 <body>

--- a/coupon.js
+++ b/coupon.js
@@ -1,5 +1,8 @@
 import { loadJSON } from './utils/dataLoader.js';
-import { sortItemsByCategory } from './utils/sortByCategory.js';
+import {
+  sortItemsByCategory,
+  renderItemsWithCategoryHeaders
+} from './utils/sortByCategory.js';
 
 const NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
 
@@ -165,10 +168,9 @@ async function init() {
   const container = document.getElementById('coupons');
   const [needs, coupons] = await Promise.all([loadNeeds(), loadCoupons()]);
   const sortedNeeds = sortItemsByCategory(needs);
-  sortedNeeds.forEach(n => {
-    const row = createRow(n, coupons);
-    container.appendChild(row);
-  });
+  renderItemsWithCategoryHeaders(sortedNeeds, container, n =>
+    createRow(n, coupons)
+  );
   await saveCoupons(coupons);
 }
 

--- a/expiration.html
+++ b/expiration.html
@@ -7,6 +7,10 @@
     body { font-family: Arial, sans-serif; width: 300px; }
     .item { margin-bottom: 10px; }
     input[type="number"] { width: 60px; }
+    .category-header {
+      border-top: 1px solid #ccc;
+      margin-top: 10px;
+    }
   </style>
 </head>
 <body>

--- a/expiration.js
+++ b/expiration.js
@@ -1,5 +1,8 @@
 import { loadJSON } from './utils/dataLoader.js';
-import { sortItemsByCategory } from './utils/sortByCategory.js';
+import {
+  sortItemsByCategory,
+  renderItemsWithCategoryHeaders
+} from './utils/sortByCategory.js';
 
 const NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
 const EXPIRATION_PATH = 'Required for grocery app/expiration_times_full.json';
@@ -75,10 +78,9 @@ async function init() {
   const sortedNeeds = sortItemsByCategory(needs);
   const expMap = new Map(expiration.map(e => [e.name, e]));
   const container = document.getElementById('expirations');
-  sortedNeeds.forEach(n => {
-    const row = createRow(n, expMap, expiration);
-    container.appendChild(row);
-  });
+  renderItemsWithCategoryHeaders(sortedNeeds, container, n =>
+    createRow(n, expMap, expiration)
+  );
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/inventory.html
+++ b/inventory.html
@@ -7,6 +7,10 @@
     body { font-family: Arial, sans-serif; width: 300px; }
     .item { margin-bottom: 10px; }
     input[type="number"] { width: 60px; }
+    .category-header {
+      border-top: 1px solid #ccc;
+      margin-top: 10px;
+    }
   </style>
 </head>
 <body>

--- a/inventory.js
+++ b/inventory.js
@@ -1,6 +1,9 @@
 import { loadJSON } from './utils/dataLoader.js';
 import { getStockForWeek } from './utils/timeline.js';
-import { sortItemsByCategory } from './utils/sortByCategory.js';
+import {
+  sortItemsByCategory,
+  renderItemsWithCategoryHeaders
+} from './utils/sortByCategory.js';
 
 const STOCK_PATH = 'Required for grocery app/current_stock_table.json';
 const CONSUMPTION_PATH = 'Required for grocery app/monthly_consumption_table.json';
@@ -123,10 +126,9 @@ function renderWeek(week) {
   const sortedStock = sortItemsByCategory(
     baseStock.map(it => ({ ...it, category: categoryMap.get(it.name) || '' }))
   );
-  sortedStock.forEach(item => {
+  renderItemsWithCategoryHeaders(sortedStock, container, item => {
     const amt = stockForWeek.get(item.name) || 0;
-    const row = createItemRow(item.name, amt, item.unit, purchasesMap, week);
-    container.appendChild(row);
+    return createItemRow(item.name, amt, item.unit, purchasesMap, week);
   });
 }
 

--- a/inventoryTimeline.css
+++ b/inventoryTimeline.css
@@ -8,3 +8,7 @@ th, td { border: 1px solid #ccc; padding: 2px 4px; text-align: center; }
 .red { background-color: #ffcdd2; }
 .exp-weeks { font-size: 0.8em; color: #666; }
 .weekly-cons { font-size: 0.8em; color: #666; }
+.category-header {
+  border-top: 1px solid #ccc;
+  text-align: left;
+}

--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -160,7 +160,19 @@ function buildGrid(items) {
   }
   grid.appendChild(header);
 
+  let lastCat = null;
   items.forEach(item => {
+    const cat = item.category || 'Other';
+    if (cat !== lastCat) {
+      lastCat = cat;
+      const catRow = document.createElement('tr');
+      const thCat = document.createElement('th');
+      thCat.colSpan = 53;
+      thCat.className = 'category-header';
+      thCat.textContent = cat;
+      catRow.appendChild(thCat);
+      grid.appendChild(catRow);
+    }
     const overrides = {};
     if (item.overrideWeeks) Object.assign(overrides, item.overrideWeeks);
     const weeks = simulateItem(item, overrides);

--- a/popup.html
+++ b/popup.html
@@ -19,6 +19,10 @@
       justify-content: space-between;
       align-items: center;
     }
+    .category-header {
+      border-top: 1px solid #ccc;
+      margin-top: 10px;
+    }
   </style>
 </head>
 <body>

--- a/popup.js
+++ b/popup.js
@@ -1,7 +1,10 @@
 import { loadJSON } from './utils/dataLoader.js';
 import { calculatePurchaseNeeds } from './utils/purchaseCalculator.js';
 import { initUomTable, convert } from './utils/uomConverter.js';
-import { sortItemsByCategory } from './utils/sortByCategory.js';
+import {
+  sortItemsByCategory,
+  renderItemsWithCategoryHeaders
+} from './utils/sortByCategory.js';
 
 const YEARLY_NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
 const STORE_SELECTION_PATH = 'Required for grocery app/store_selection_stopandshop.json';
@@ -134,7 +137,7 @@ async function init() {
   const stockMap = new Map(stock.map(i => [i.name, i]));
   const itemsContainer = document.getElementById('items');
 
-  sortedNeeds.forEach(item => {
+  renderItemsWithCategoryHeaders(sortedNeeds, itemsContainer, item => {
     const li = document.createElement('li');
     const info = purchaseMap.get(item.name);
     const needAmt = info ? Math.round(info.toBuy) : null;
@@ -185,7 +188,7 @@ async function init() {
     li.appendChild(finalSpan);
     li.appendChild(finalImg);
     finalMap.set(item.name, { li, btn, span: finalSpan, img: finalImg });
-    itemsContainer.appendChild(li);
+    return li;
   });
 }
 

--- a/removeItem.html
+++ b/removeItem.html
@@ -7,6 +7,10 @@
     body { font-family: Arial, sans-serif; width: 300px; }
     li { margin-bottom: 10px; }
     .confirm { margin-top: 5px; }
+    .category-header {
+      border-top: 1px solid #ccc;
+      margin-top: 10px;
+    }
   </style>
 </head>
 <body>

--- a/removeItem.js
+++ b/removeItem.js
@@ -1,5 +1,8 @@
 import { loadJSON } from './utils/dataLoader.js';
-import { sortItemsByCategory } from './utils/sortByCategory.js';
+import {
+  sortItemsByCategory,
+  renderItemsWithCategoryHeaders
+} from './utils/sortByCategory.js';
 
 const YEARLY_NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
 const CONSUMPTION_PATH = 'Required for grocery app/monthly_consumption_table.json';
@@ -161,9 +164,9 @@ async function init() {
   const items = await loadNeeds();
   const sortedItems = sortItemsByCategory(items);
   const ul = document.getElementById('items');
-  sortedItems.forEach(it => {
-    ul.appendChild(createListItem(it.name));
-  });
+  renderItemsWithCategoryHeaders(sortedItems, ul, it =>
+    createListItem(it.name)
+  );
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/utils/sortByCategory.js
+++ b/utils/sortByCategory.js
@@ -8,3 +8,19 @@ export function sortItemsByCategory(arr) {
     return catA.localeCompare(catB);
   });
 }
+
+export function renderItemsWithCategoryHeaders(items, container, renderFn) {
+  let lastCat = null;
+  items.forEach(item => {
+    const cat = item.category || 'Other';
+    if (cat !== lastCat) {
+      lastCat = cat;
+      const header = document.createElement('h3');
+      header.className = 'category-header';
+      header.textContent = cat;
+      container.appendChild(header);
+    }
+    const node = renderFn(item);
+    if (node) container.appendChild(node);
+  });
+}


### PR DESCRIPTION
## Summary
- group items under category headers using new utility `renderItemsWithCategoryHeaders`
- display category headers in inventory, coupons, expiration, popup, consumption, removal pages and timeline grid
- add basic styling for category headers

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6852ce0b7308832982b80c091c952e0a