### PR TITLE
Fix category headers in inventory timeline

### DIFF
--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -85,6 +85,7 @@ function buildItemMap(needs, expiration, stock) {
 
   return needs.map(n => ({
     name: n.name,
+    category: n.category || '',
     units_per_purchase: 1,
     weekly_consumption: n.total_needed_year / 52,
     expiration_weeks: expMap[n.name] || 52,


### PR DESCRIPTION
## Summary
- preserve item categories when creating timeline map
- show each category header in the inventory timeline grid

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6852da0d097483298e20d169484936e6