### PR TITLE
Add consumption plan editor

### DIFF
--- a/plan.html
+++ b/plan.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Consumption Plan</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 300px; }
+    .item { margin-bottom: 10px; }
+    input[type="number"] { width: 60px; }
+    .category-header {
+      border-top: 1px solid #ccc;
+      margin-top: 10px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Consumption Plan</h1>
+  <div id="plan"></div>
+  <script type="module" src="plan.js"></script>
+</body>
+</html>

--- a/plan.js
+++ b/plan.js
@@ -1,0 +1,60 @@
+import { loadJSON } from './utils/dataLoader.js';
+import { sortItemsByCategory, renderItemsWithCategoryHeaders } from './utils/sortByCategory.js';
+
+const NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
+const KEY = 'yearlyNeeds';
+
+function loadNeeds() {
+  return new Promise(async resolve => {
+    chrome.storage.local.get(KEY, async data => {
+      if (data[KEY]) {
+        resolve(data[KEY]);
+      } else {
+        const arr = await loadJSON(NEEDS_PATH);
+        resolve(arr);
+      }
+    });
+  });
+}
+
+function saveNeeds(arr) {
+  return new Promise(resolve => {
+    chrome.storage.local.set({ [KEY]: arr }, () => resolve());
+  });
+}
+
+function createRow(item, needs) {
+  const div = document.createElement('div');
+  div.className = 'item';
+  const span = document.createElement('span');
+  const weekly = item.total_needed_year ? item.total_needed_year / 52 : 0;
+  span.textContent = `${item.name} - ${weekly.toFixed(2)} /wk`;
+  div.appendChild(span);
+
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.placeholder = 'Per week';
+  input.addEventListener('keydown', async e => {
+    if (e.key === 'Enter') {
+      const val = parseFloat(input.value);
+      if (!isNaN(val)) {
+        item.total_needed_year = val * 52;
+        span.textContent = `${item.name} - ${val.toFixed(2)} /wk`;
+        input.value = '';
+        await saveNeeds(needs);
+      }
+    }
+  });
+  div.appendChild(document.createTextNode(' '));
+  div.appendChild(input);
+  return div;
+}
+
+async function init() {
+  const needs = await loadNeeds();
+  const sorted = sortItemsByCategory(needs);
+  const container = document.getElementById('plan');
+  renderItemsWithCategoryHeaders(sorted, container, item => createRow(item, needs));
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/popup.html
+++ b/popup.html
@@ -32,6 +32,7 @@
       <button id="commit">Commit</button>
       <button id="editInventory">Edit Inventory</button>
       <button id="editConsumption">Edit Consumption</button>
+      <button id="editPlan">Edit Plan</button>
       <button id="addItem">Add Item</button>
       <button id="removeItem">Remove Item</button>
       <button id="editCategory">Edit Category</button>

--- a/popup.js
+++ b/popup.js
@@ -437,6 +437,13 @@ document
   .getElementById('editExpirations')
   .addEventListener('click', openExpirationEditor);
 
+function openPlanEditor() {
+  const url = chrome.runtime.getURL('plan.html');
+  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+}
+
+document.getElementById('editPlan').addEventListener('click', openPlanEditor);
+
 function openCouponManager() {
   const url = chrome.runtime.getURL('coupon.html');
   chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });


### PR DESCRIPTION
## Summary
- add Edit Plan button in the main popup
- open new window for editing weekly consumption
- implement new Consumption Plan page and logic

## Testing
- `node --check plan.js`
- `node --check popup.js`


------
https://chatgpt.com/codex/tasks/task_e_6852e75313388329ba409533a6d37f87