### PR TITLE
Add consumption plan editor page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ step‑by‑step.
 * Lets you save the final product you want with its picture and price.
 * Can create a shopping list and update your pantry when you press **Commit**.
 * Allows you to edit your pantry and how much you have used.
+* Lets you set a monthly and yearly consumption plan.
 * Lets you add new grocery items to track.
 
 ## Installing the add-on
@@ -45,9 +46,10 @@ step‑by‑step.
    your pantry amounts are updated.
 9. Use **Edit Inventory** to change what you have on hand.
 10. Use **Edit Consumption** to record how much you used this year.
-11. Click **Add Item** if you want to track something new.
-12. Click **Remove Item** to delete an item you no longer want to track.
-13. Click **Coupons** to manage temporary discounts for each item.
+11. Use **Edit Consumption Plan** to adjust your monthly and yearly needs.
+12. Click **Add Item** if you want to track something new.
+13. Click **Remove Item** to delete an item you no longer want to track.
+14. Click **Coupons** to manage temporary discounts for each item.
 
 That’s it! You can close the windows when you are done. The add-on keeps the
 information so you can refer to it later.

--- a/consumptionPlan.html
+++ b/consumptionPlan.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Edit Consumption Plan</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 300px; }
+    .item { margin-bottom: 10px; }
+    input[type="number"] { width: 60px; }
+    .category-header {
+      border-top: 1px solid #ccc;
+      margin-top: 10px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Edit Consumption Plan</h1>
+  <div id="plan"></div>
+  <script type="module" src="consumptionPlan.js"></script>
+</body>
+</html>

--- a/consumptionPlan.js
+++ b/consumptionPlan.js
@@ -1,0 +1,122 @@
+import { loadJSON } from './utils/dataLoader.js';
+import { sortItemsByCategory, renderItemsWithCategoryHeaders } from './utils/sortByCategory.js';
+
+const NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
+const CONSUMPTION_PATH = 'Required for grocery app/monthly_consumption_table.json';
+
+function loadArray(key, path) {
+  return new Promise(async resolve => {
+    chrome.storage.local.get(key, async data => {
+      if (data[key]) {
+        resolve(data[key]);
+      } else {
+        const arr = await loadJSON(path);
+        resolve(arr);
+      }
+    });
+  });
+}
+
+const loadNeeds = () => loadArray('yearlyNeeds', NEEDS_PATH);
+const loadConsumption = () => loadArray('monthlyConsumption', CONSUMPTION_PATH);
+
+function saveNeeds(arr) {
+  return new Promise(resolve => {
+    chrome.storage.local.set({ yearlyNeeds: arr }, () => resolve());
+  });
+}
+
+function saveConsumption(arr) {
+  return new Promise(resolve => {
+    chrome.storage.local.set({ monthlyConsumption: arr }, () => resolve());
+  });
+}
+
+function sendUpdate() {
+  try {
+    chrome.runtime.sendMessage({ type: 'plan-updated' });
+  } catch (_) {}
+}
+
+function createRow(item, consMap, needsMap, consArr, needsArr) {
+  const div = document.createElement('div');
+  div.className = 'item';
+  const span = document.createElement('span');
+  const monthly = consMap.get(item.name)?.monthly_consumption || 0;
+  const yearly = needsMap.get(item.name)?.total_needed_year || 0;
+  span.textContent = `${item.name} - ${monthly}/mo - ${yearly} yr`;
+  div.appendChild(span);
+
+  const mInput = document.createElement('input');
+  mInput.type = 'number';
+  mInput.placeholder = 'Monthly';
+  mInput.step = 'any';
+  async function commitMonthly() {
+    const val = parseFloat(mInput.value);
+    if (!isNaN(val)) {
+      let rec = consMap.get(item.name);
+      if (!rec) {
+        rec = { name: item.name, monthly_consumption: val, unit: item.home_unit };
+        consArr.push(rec);
+        consMap.set(item.name, rec);
+      } else {
+        rec.monthly_consumption = val;
+      }
+      span.textContent = `${item.name} - ${val}/mo - ${yearly} yr`;
+      mInput.value = '';
+      await saveConsumption(consArr);
+      sendUpdate();
+    }
+  }
+  mInput.addEventListener('keydown', e => { if (e.key === 'Enter') commitMonthly(); });
+  mInput.addEventListener('blur', commitMonthly);
+
+  const yInput = document.createElement('input');
+  yInput.type = 'number';
+  yInput.placeholder = 'Yearly';
+  yInput.step = 'any';
+  async function commitYearly() {
+    const val = parseFloat(yInput.value);
+    if (!isNaN(val)) {
+      let rec = needsMap.get(item.name);
+      if (!rec) {
+        rec = {
+          name: item.name,
+          total_needed_year: val,
+          home_unit: item.home_unit,
+          treat_as_whole_unit: item.treat_as_whole_unit,
+          category: item.category || ''
+        };
+        needsArr.push(rec);
+        needsMap.set(item.name, rec);
+      } else {
+        rec.total_needed_year = val;
+      }
+      span.textContent = `${item.name} - ${monthly}/mo - ${val} yr`;
+      yInput.value = '';
+      await saveNeeds(needsArr);
+      sendUpdate();
+    }
+  }
+  yInput.addEventListener('keydown', e => { if (e.key === 'Enter') commitYearly(); });
+  yInput.addEventListener('blur', commitYearly);
+
+  div.appendChild(document.createTextNode(' '));
+  div.appendChild(mInput);
+  div.appendChild(document.createTextNode(' '));
+  div.appendChild(yInput);
+  return div;
+}
+
+async function init() {
+  const [consumption, needs] = await Promise.all([loadConsumption(), loadNeeds()]);
+  const sortedNeeds = sortItemsByCategory(needs);
+  const consMap = new Map(consumption.map(c => [c.name, c]));
+  const needsMap = new Map(needs.map(n => [n.name, n]));
+  const container = document.getElementById('plan');
+  renderItemsWithCategoryHeaders(sortedNeeds, container, item =>
+    createRow(item, consMap, needsMap, consumption, needs)
+  );
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -361,7 +361,7 @@ async function init() {
 
   try {
     chrome.runtime.onMessage.addListener(msg => {
-      if (msg && msg.type === 'inventory-updated') {
+      if (msg && (msg.type === 'inventory-updated' || msg.type === 'plan-updated')) {
         if (showingHistory) {
           showPurchaseHistory();
         } else {

--- a/popup.html
+++ b/popup.html
@@ -32,6 +32,7 @@
       <button id="commit">Commit</button>
       <button id="editInventory">Edit Inventory</button>
       <button id="editConsumption">Edit Consumption</button>
+      <button id="editConsumptionPlan">Edit Consumption Plan</button>
       <button id="addItem">Add Item</button>
       <button id="removeItem">Remove Item</button>
       <button id="editCategory">Edit Category</button>

--- a/popup.js
+++ b/popup.js
@@ -224,6 +224,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         img.style.display = 'inline';
       }
     }
+  } else if (message.type === 'plan-updated') {
+    location.reload();
   }
 });
 
@@ -402,6 +404,15 @@ function openConsumption() {
 document
   .getElementById('editConsumption')
   .addEventListener('click', openConsumption);
+
+function openConsumptionPlan() {
+  const url = chrome.runtime.getURL('consumptionPlan.html');
+  chrome.windows.create({ url, type: 'popup', width: 400, height: 600 });
+}
+
+document
+  .getElementById('editConsumptionPlan')
+  .addEventListener('click', openConsumptionPlan);
 
 function openAddItem() {
   const url = chrome.runtime.getURL("addItem.html");


### PR DESCRIPTION
## Summary
- add new Edit Consumption Plan page to modify monthly and yearly usage
- refresh popup and timeline when the plan changes
- add button in popup to open the new page
- document the new workflow and feature in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852efd013608329a6e4b0a4086fe925