### PR TITLE
Fix timeline refresh on plan changes

### DIFF
--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -333,7 +333,12 @@ async function init() {
   chrome.storage.onChanged.addListener(async (changes, area) => {
     if (area !== 'local') return;
 
-    if (changes.yearlyNeeds || changes.expirationData || changes.currentStock) {
+    if (
+      changes.yearlyNeeds ||
+      changes.expirationData ||
+      changes.currentStock ||
+      changes.monthlyConsumption
+    ) {
       await refreshItems();
       return;
     }
@@ -371,13 +376,9 @@ async function init() {
   });
 
   try {
-    chrome.runtime.onMessage.addListener(msg => {
+    chrome.runtime.onMessage.addListener(async msg => {
       if (msg && msg.type === 'inventory-updated') {
-        if (showingHistory) {
-          showPurchaseHistory();
-        } else {
-          showGrid();
-        }
+        await refreshItems();
       }
     });
   } catch (_) {}


### PR DESCRIPTION
## Summary
- refresh inventory timeline when changing consumption plan

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685319f569f4832996de082e9d7d9827