### PR TITLE
Improve Shaw's scraper with name-based size fallback

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -442,6 +442,16 @@ function scrapeShaws() {
       }
     }
 
+    if (sizeQty == null && name) {
+      const m = name.match(/([\d.]+)\s*(fl\s*oz|oz|lb|g|kg|ml|l|gal|qt|pt|cup|tbsp|tsp|ea|ct|count|pkg|box|can|bag|bottle|stick|roll|bar|pouch|jar|packet|sleeve|slice|piece|tube|tray|unit)/i);
+      if (m) {
+        sizeQty = parseFloat(m[1]);
+        sizeUnit = m[2].toLowerCase().replace(/\s+/g, '');
+        if (sizeUnit === 'floz') sizeUnit = 'oz';
+        else if (sizeUnit === 'count') sizeUnit = 'ct';
+      }
+    }
+
     let convertedQty = null;
     let pricePerUnit = null;
     if (sizeQty != null && sizeUnit) {


### PR DESCRIPTION
## Summary
- add a fallback in `scrapeShaws` within `contentScript.js` to parse quantities from product names when size tags are missing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685321aefc4083298d9e1b5d00e86c14