### PR TITLE
Fix Amazon unit parsing and pack price

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -275,7 +275,7 @@ function scrapeAmazon() {
     let unit = null;
     for (const field of fields) {
       if (!field) continue;
-      const m = field.match(/([\d.]+)[\s-]*(oz|ounce|fluid ounce|fl oz|g|gram|kg|ml|l)/i);
+      const m = field.match(/([\d.]+)[\s-]*(oz|ounce|fluid ounce|fl oz|g|gram|kg|ml|l|gal|gallon|gallons)\b/i);
       if (m) {
         unitSize = parseFloat(m[1]);
         unit = m[2].toLowerCase();
@@ -286,6 +286,7 @@ function scrapeAmazon() {
       unit = unit.replace(/\s+/g, '');
       if (unit === 'ounce' || unit === 'ounces' || unit === 'floz' || unit === 'fluidounce' || unit === 'flounce') unit = 'oz';
       else if (unit === 'gram') unit = 'g';
+      else if (unit === 'gallon' || unit === 'gallons') unit = 'gal';
     }
 
     const packFields = [name, unitText, sizeText];
@@ -343,6 +344,11 @@ function scrapeAmazon() {
         pricePerUnit = priceNumber / packCount;
       }
     } else if (!unitText && priceNumber != null && packCount) {
+      pricePerUnit = priceNumber / packCount;
+      unitType = 'count';
+    }
+
+    if (pricePerUnit == null && priceNumber != null && packCount > 1) {
       pricePerUnit = priceNumber / packCount;
       unitType = 'count';
     }

--- a/scrapers/amazon.js
+++ b/scrapers/amazon.js
@@ -40,7 +40,7 @@ export function scrapeAmazon() {
     let unit = null;
     for (const field of fields) {
       if (!field) continue;
-      const m = field.match(/([\d.]+)[\s-]*(oz|ounce|fluid ounce|fl oz|g|gram|kg|ml|l)/i);
+      const m = field.match(/([\d.]+)[\s-]*(oz|ounce|fluid ounce|fl oz|g|gram|kg|ml|l|gal|gallon|gallons)\b/i);
       if (m) {
         unitSize = parseFloat(m[1]);
         unit = m[2].toLowerCase();
@@ -51,6 +51,7 @@ export function scrapeAmazon() {
       unit = unit.replace(/\s+/g, '');
       if (unit === 'ounce' || unit === 'ounces' || unit === 'floz' || unit === 'fluidounce' || unit === 'flounce') unit = 'oz';
       else if (unit === 'gram') unit = 'g';
+      else if (unit === 'gallon' || unit === 'gallons') unit = 'gal';
     }
 
     const packFields = [name, unitText, sizeText];
@@ -108,6 +109,11 @@ export function scrapeAmazon() {
         pricePerUnit = priceNumber / packCount;
       }
     } else if (!unitText && priceNumber != null && packCount) {
+      pricePerUnit = priceNumber / packCount;
+      unitType = 'count';
+    }
+
+    if (pricePerUnit == null && priceNumber != null && packCount > 1) {
       pricePerUnit = priceNumber / packCount;
       unitType = 'count';
     }


### PR DESCRIPTION
## Summary
- handle gallon units in `parseUnitInfo`
- compute price per count when unit price isn't found

## Testing
- `node --check scrapers/amazon.js`
- `node --check contentScript.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68533149b8e88329954684b6e4c947ae