### PR TITLE
Add sticky headers to inventory timeline

### DIFF
--- a/inventoryTimeline.css
+++ b/inventoryTimeline.css
@@ -1,8 +1,23 @@
-body { font-family: Arial, sans-serif; overflow-x: auto; }
+body { font-family: Arial, sans-serif; overflow: auto; }
 #controls { margin-bottom: 10px; }
-#grid-container { overflow-x: auto; }
+#grid-container { overflow: auto; max-height: 80vh; position: relative; }
 table { border-collapse: collapse; }
 th, td { border: 1px solid #ccc; padding: 2px 4px; text-align: center; }
+.item-label {
+  position: sticky;
+  left: 0;
+  background: #fff;
+  z-index: 1;
+}
+tr:first-child th {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  z-index: 2;
+}
+tr:first-child th.item-label {
+  z-index: 3;
+}
 .green { background-color: #c8e6c9; }
 .yellow { background-color: #fff9c4; }
 .red { background-color: #ffcdd2; }

--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -159,6 +159,7 @@ function buildGrid(items) {
   const header = document.createElement('tr');
   const firstTh = document.createElement('th');
   firstTh.textContent = 'Item';
+  firstTh.className = 'item-label';
   header.appendChild(firstTh);
   for (let w=1; w<=52; w++) {
     const th = document.createElement('th');
@@ -185,6 +186,7 @@ function buildGrid(items) {
     const weeks = simulateItem(item, overrides);
     const row = document.createElement('tr');
     const th = document.createElement('th');
+    th.className = 'item-label';
     th.innerHTML = `${item.name}<br/><span class="exp-weeks">${item.expiration_weeks}w</span>` +
       `<br/><span class="weekly-cons">${item.weekly_consumption.toFixed(2)}/wk</span>`;
     row.appendChild(th);


### PR DESCRIPTION
## Summary
- keep the first column and header row in view while scrolling the timeline

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853e550171883299932debffc8d9cce