### PR TITLE
Fix inventory week display

### DIFF
--- a/inventory.js
+++ b/inventory.js
@@ -1,5 +1,5 @@
 import { loadJSON } from './utils/dataLoader.js';
-import { getStockForWeek } from './utils/timeline.js';
+import { getStockBeforeWeek } from './utils/timeline.js';
 import { WEEKS_PER_MONTH } from './utils/constants.js';
 import {
   sortItemsByCategory,
@@ -71,7 +71,7 @@ function createItemRow(name, amount, unit, purchasesMap, week) {
   const div = document.createElement('div');
   div.className = 'item';
   const span = document.createElement('span');
-  span.textContent = `${name} - ${amount} ${unit}`;
+  span.textContent = `${name} - ${amount.toFixed(2)} ${unit}`;
   div.appendChild(span);
 
   const input = document.createElement('input');
@@ -94,7 +94,7 @@ function createItemRow(name, amount, unit, purchasesMap, week) {
         } catch (_) {}
         amount = val;
       }
-      span.textContent = `${name} - ${amount} ${unit}`;
+      span.textContent = `${name} - ${amount.toFixed(2)} ${unit}`;
       input.value = '';
     }
   }
@@ -123,7 +123,7 @@ function renderWeek(week) {
     consumptionData,
     expirationData
   );
-  const stockArr = getStockForWeek(timelineItems, purchasesMap, week);
+  const stockArr = getStockBeforeWeek(timelineItems, purchasesMap, week);
   const stockForWeek = new Map(stockArr.map(i => [i.name, i.amount]));
   const sortedStock = sortItemsByCategory(
     baseStock.map(it => ({ ...it, category: categoryMap.get(it.name) || '' }))

--- a/utils/timeline.js
+++ b/utils/timeline.js
@@ -9,6 +9,17 @@ export function getStockForWeek(items, purchases = {}, week = 1) {
   });
 }
 
+export function getStockBeforeWeek(items, purchases = {}, week = 1) {
+  return items.map(item => {
+    const simItem = {
+      ...item,
+      purchases: purchases[item.name] || []
+    };
+    const qty = simulateBeforeWeek(simItem, week);
+    return { name: item.name, amount: qty };
+  });
+}
+
 function simulateForWeek(item, week) {
   const incoming = [];
   const active = [];
@@ -41,4 +52,48 @@ function simulateForWeek(item, week) {
     }
   }
   return active.reduce((sum,b)=>sum+b.qty,0);
+}
+
+function simulateBeforeWeek(item, week) {
+  const incoming = [];
+  const active = [];
+  if (item.starting_stock > 0) {
+    incoming.push({ start: 1, qty: item.starting_stock, exp: 1 + item.expiration_weeks });
+  }
+  (item.purchases || []).forEach(p => {
+    const exp = p.manual_expiration_override || item.expiration_weeks;
+    incoming.push({ start: p.purchase_week, qty: p.quantity_purchased, exp: p.purchase_week + exp });
+  });
+  incoming.sort((a, b) => a.start - b.start);
+
+  for (let w = 1; w < week; w++) {
+    while (incoming.length && incoming[0].start <= w) {
+      active.push(incoming.shift());
+    }
+    active.sort((a, b) => a.exp - b.exp);
+    while (active.length && w >= active[0].exp) {
+      active.shift();
+    }
+    let remaining = item.weekly_consumption;
+    while (active.length && remaining > 0) {
+      if (active[0].qty > remaining) {
+        active[0].qty -= remaining;
+        remaining = 0;
+      } else {
+        remaining -= active[0].qty;
+        active.shift();
+      }
+    }
+  }
+
+  const w = week;
+  while (incoming.length && incoming[0].start <= w) {
+    active.push(incoming.shift());
+  }
+  active.sort((a, b) => a.exp - b.exp);
+  while (active.length && w >= active[0].exp) {
+    active.shift();
+  }
+
+  return active.reduce((sum, b) => sum + b.qty, 0);
 }


### PR DESCRIPTION
## Summary
- show inventory before weekly consumption
- round inventory display to two decimals

## Testing
- `node -e "require('./inventory.js');"` *(fails: document is not defined)*
- `node -e "require('./utils/timeline.js');"`

------
https://chatgpt.com/codex/tasks/task_e_6853fc2166e88329bac5ee6d1887f462