### PR TITLE
Add per-item save buttons for UOM changes

### DIFF
--- a/uomChange.html
+++ b/uomChange.html
@@ -25,11 +25,11 @@
         <th>New UOM</th>
         <th>Treat as Whole</th>
         <th>Change</th>
+        <th>Save</th>
       </tr>
     </thead>
     <tbody id="uom-list"></tbody>
   </table>
-  <button id="saveBtn" class="hidden">Save</button>
   <script type="module" src="uomChange.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Save column with per-item buttons
- remove global save control
- handle showing save when row values change
- update saving logic to persist a single row

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_685426ea63708329a2af0677a127c7b6