### PR TITLE
Fix treat as whole unit flag update in UOM changer

### DIFF
--- a/uomChange.js
+++ b/uomChange.js
@@ -62,7 +62,7 @@ function buildRow(item) {
   saveBtn.textContent = 'Save';
   saveBtn.className = 'hidden';
   saveTd.appendChild(saveBtn);
-  const row = { tr, input, chk, item, saveBtn };
+  const row = { tr, input, chk, item, saveBtn, homeTd, wholeTd };
 
   input.addEventListener('input', () => updateSaveVisibility(row));
   chk.addEventListener('change', () => updateSaveVisibility(row));
@@ -121,9 +121,11 @@ async function saveRow(row) {
     if (cons) cons.unit = newUnit;
     const st = stock.find(s => s.name === row.item.name);
     if (st) st.unit = newUnit;
+    row.homeTd.textContent = newUnit;
   }
   if (changedWhole) {
     row.item.treat_as_whole_unit = row.chk.checked;
+    row.wholeTd.textContent = row.item.treat_as_whole_unit;
   }
 
   await Promise.all([


### PR DESCRIPTION
## Summary
- store table cells in row object when building rows
- update cell values after saving to reflect new unit and treat-as-whole flag

## Testing
- `node -c uomChange.js`

------
https://chatgpt.com/codex/tasks/task_e_68542e66e9b08329943367805991cdaa