### PR TITLE
Handle gallon abbreviations in Walmart scraper

### DIFF
--- a/scrapers/walmart.js
+++ b/scrapers/walmart.js
@@ -7,6 +7,7 @@ export function scrapeWalmart() {
     ml: 0.033814,
     l: 33.814,
     gal: 128,
+    ga: 128,
     qt: 32,
     pt: 16,
     cup: 8,


### PR DESCRIPTION
## Summary
- recognize `ga` as gallon in Walmart scraper

## Testing
- `node -v`
- run a quick Node script to confirm `/ga` per-unit conversion

------
https://chatgpt.com/codex/tasks/task_e_68543774b9348329addd1408c3c0f669