### PR TITLE
Fix count-based unit handling

### DIFF
--- a/item.js
+++ b/item.js
@@ -243,7 +243,9 @@ async function init() {
     if (selected) {
       let pStr = selected.priceNumber != null ? `$${selected.priceNumber.toFixed(2)}` : selected.price;
       let qStr = selected.convertedQty != null ? `${selected.convertedQty.toFixed(2)} oz` : selected.size;
-      let uStr = selected.pricePerUnit != null ? `$${selected.pricePerUnit.toFixed(2)}/oz` : selected.unit;
+      let uStr = selected.pricePerUnit != null
+        ? `$${selected.pricePerUnit.toFixed(2)}/${selected.unitType || 'oz'}`
+        : selected.unit;
       const cost = monthlyCost(itemName, selected);
       const costStr = cost != null ? ` - $${cost.toFixed(2)}/mo` : '';
       info.textContent = `${selected.name} - ${pStr} - ${qStr} - ${uStr}${costStr}`;
@@ -283,7 +285,7 @@ async function init() {
             : selected.size;
         let uStr =
           selected.pricePerUnit != null
-            ? `$${selected.pricePerUnit.toFixed(2)}/oz`
+            ? `$${selected.pricePerUnit.toFixed(2)}/${selected.unitType || 'oz'}`
             : selected.unit;
         const cost = monthlyCost(itemName, selected);
         const costStr = cost != null ? ` - $${cost.toFixed(2)}/mo` : '';

--- a/popup.js
+++ b/popup.js
@@ -325,7 +325,7 @@ function formatFinalText(itemName, store, product) {
         : product.size;
     let uStr =
       product.pricePerUnit != null
-        ? `$${product.pricePerUnit.toFixed(2)}/oz`
+        ? `$${product.pricePerUnit.toFixed(2)}/${product.unitType || 'oz'}`
         : product.unit;
     const cost = monthlyCost(itemName, product);
     const costStr = cost != null ? ` - $${cost.toFixed(2)}/mo` : '';

--- a/scrapeResults.js
+++ b/scrapeResults.js
@@ -211,7 +211,9 @@ async function init() {
 
     let pStr = prod.priceNumber != null ? `$${prod.priceNumber.toFixed(2)}` : prod.price;
     let qStr = prod.convertedQty != null ? `${prod.convertedQty.toFixed(2)} oz` : prod.size;
-    let uStr = prod.pricePerUnit != null ? `$${prod.pricePerUnit.toFixed(2)}/oz` : prod.unit;
+    let uStr = prod.pricePerUnit != null
+      ? `$${prod.pricePerUnit.toFixed(2)}/${prod.unitType || 'oz'}`
+      : prod.unit;
     const cost = monthlyCost(item, prod);
     const costStr = cost != null ? ` - $${cost.toFixed(2)}/mo` : '';
     const info = document.createElement('span');

--- a/scrapers/stopandshop.js
+++ b/scrapers/stopandshop.js
@@ -34,6 +34,27 @@ export function scrapeStopAndShop() {
     tray: 1,
     unit: 1
   };
+  const COUNT_UNITS = new Set([
+    'ea',
+    'ct',
+    'pkg',
+    'box',
+    'can',
+    'bag',
+    'bottle',
+    'stick',
+    'roll',
+    'bar',
+    'pouch',
+    'jar',
+    'packet',
+    'sleeve',
+    'slice',
+    'piece',
+    'tube',
+    'tray',
+    'unit'
+  ]);
 
   const products = [];
   const tiles = document.querySelectorAll('li.tile.product-cell.product-grid-cell');
@@ -94,7 +115,7 @@ export function scrapeStopAndShop() {
         unitType = m[3].toLowerCase().replace(/\s+/g, '');
         if (unitType === 'floz') unitType = 'oz';
         const factor = UNIT_FACTORS[unitType];
-        if (factor) {
+        if (factor && !COUNT_UNITS.has(unitType)) {
           pricePerUnit = pricePerUnit / factor;
           unitType = 'oz';
         }
@@ -104,11 +125,16 @@ export function scrapeStopAndShop() {
     if (sizeQty != null && sizeUnit) {
       const factor = UNIT_FACTORS[sizeUnit.toLowerCase()];
       if (factor) {
-        convertedQty = sizeQty * factor;
+        const isCount = COUNT_UNITS.has(sizeUnit.toLowerCase());
+        if (!isCount) {
+          convertedQty = sizeQty * factor;
+        }
         if (priceNumber != null && pricePerUnit == null) {
-          const totalConverted = convertedQty * packCount;
-          pricePerUnit = priceNumber / totalConverted;
-          unitType = 'oz';
+          const total = isCount
+            ? sizeQty * packCount
+            : (convertedQty * packCount);
+          pricePerUnit = priceNumber / total;
+          unitType = isCount ? sizeUnit.toLowerCase() : 'oz';
         }
       }
     }

--- a/scrapers/walmart.js
+++ b/scrapers/walmart.js
@@ -33,6 +33,27 @@ export function scrapeWalmart() {
     tray: 1,
     unit: 1
   };
+  const COUNT_UNITS = new Set([
+    'ea',
+    'ct',
+    'pkg',
+    'box',
+    'can',
+    'bag',
+    'bottle',
+    'stick',
+    'roll',
+    'bar',
+    'pouch',
+    'jar',
+    'packet',
+    'sleeve',
+    'slice',
+    'piece',
+    'tube',
+    'tray',
+    'unit'
+  ]);
 
   const products = [];
   const tiles = document.querySelectorAll('[data-testid="list-view"] > div');
@@ -55,13 +76,18 @@ export function scrapeWalmart() {
       sizeUnit = sizeMatch[2].replace(/\s+/g, '');
       const factor = UNIT_FACTORS[sizeUnit.toLowerCase()];
       if (factor) {
-        convertedQty = sizeQty * factor;
-        unitType = 'oz';
+        const isCount = COUNT_UNITS.has(sizeUnit.toLowerCase());
+        if (!isCount) {
+          convertedQty = sizeQty * factor;
+        }
+        unitType = isCount ? sizeUnit.toLowerCase() : 'oz';
         if (price) {
           const p = parseFloat(price.replace(/[^0-9.]/g, ''));
           if (!isNaN(p)) {
-            const totalConverted = convertedQty * packCount;
-            pricePerUnit = p / totalConverted;
+            const total = isCount
+              ? sizeQty * packCount
+              : (convertedQty * packCount);
+            pricePerUnit = p / total;
           }
         }
       }
@@ -76,7 +102,7 @@ export function scrapeWalmart() {
         pricePerUnit = priceVal / qty;
         unitType = match[3].toLowerCase();
         const factor = UNIT_FACTORS[unitType];
-        if (factor) {
+        if (factor && !COUNT_UNITS.has(unitType)) {
           pricePerUnit = pricePerUnit / factor;
           unitType = 'oz';
         }

--- a/shoppingList.js
+++ b/shoppingList.js
@@ -43,7 +43,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const span = document.createElement('span');
         let pStr = it.product?.priceNumber != null ? `$${it.product.priceNumber.toFixed(2)}` : it.product?.price || '';
         let qStr = it.product?.convertedQty != null ? `${it.product.convertedQty.toFixed(2)} oz` : it.product?.size || '';
-        let uStr = it.product?.pricePerUnit != null ? `$${it.product.pricePerUnit.toFixed(2)}/oz` : it.product?.unit || '';
+        let uStr =
+          it.product?.pricePerUnit != null
+            ? `$${it.product.pricePerUnit.toFixed(2)}/${it.product.unitType || 'oz'}`
+            : it.product?.unit || '';
         const amt = it.amount != null ? `${it.amount.toFixed(2)} ${it.unit}` : '';
         span.textContent = `${it.item} - ${it.product?.name || ''} - ${pStr} - ${qStr} - ${uStr} - ${amt}`;
         li.appendChild(span);


### PR DESCRIPTION
## Summary
- improve Walmart scraper to preserve count-based unit types
- improve Stop & Shop scraper similarly
- show proper unit type (e.g., ct/ea) instead of always `oz`
- update UI files to use `unitType`

## Testing
- `node -c scrapers/walmart.js`
- `node -c scrapers/stopandshop.js`
- `node -c item.js`
- `node -c scrapeResults.js`
- `node -c shoppingList.js`
- `node -c popup.js`


------
https://chatgpt.com/codex/tasks/task_e_685441ccb55083299a9d84f643fd02b3