### PR TITLE
Fix unit type handling for count units

### DIFF
--- a/item.js
+++ b/item.js
@@ -258,8 +258,12 @@ async function init() {
     const selected = await loadSelected(itemName, entry.store);
     if (selected) {
       let pStr = selected.priceNumber != null ? `$${selected.priceNumber.toFixed(2)}` : selected.price;
-      let qStr = selected.convertedQty != null ? `${selected.convertedQty.toFixed(2)} oz` : selected.size;
-      let uStr = selected.pricePerUnit != null ? `$${selected.pricePerUnit.toFixed(2)}/oz` : selected.unit;
+      let qStr = selected.convertedQty != null
+        ? `${selected.convertedQty.toFixed(2)} ${selected.unitType || 'oz'}`
+        : selected.size;
+      let uStr = selected.pricePerUnit != null
+        ? `$${selected.pricePerUnit.toFixed(2)}/${selected.unitType || 'oz'}`
+        : selected.unit;
       const cost = monthlyCost(itemName, selected);
       const costStr = cost != null ? ` - $${cost.toFixed(2)}/mo` : '';
       info.textContent = `${selected.name} - ${pStr} - ${qStr} - ${uStr}${costStr}`;
@@ -295,11 +299,11 @@ async function init() {
             : selected.price;
         let qStr =
           selected.convertedQty != null
-            ? `${selected.convertedQty.toFixed(2)} oz`
+            ? `${selected.convertedQty.toFixed(2)} ${selected.unitType || 'oz'}`
             : selected.size;
         let uStr =
           selected.pricePerUnit != null
-            ? `$${selected.pricePerUnit.toFixed(2)}/oz`
+            ? `$${selected.pricePerUnit.toFixed(2)}/${selected.unitType || 'oz'}`
             : selected.unit;
         const cost = monthlyCost(itemName, selected);
         const costStr = cost != null ? ` - $${cost.toFixed(2)}/mo` : '';

--- a/popup.js
+++ b/popup.js
@@ -321,11 +321,11 @@ function formatFinalText(itemName, store, product) {
         : product.price;
     let qStr =
       product.convertedQty != null
-        ? `${product.convertedQty.toFixed(2)} oz`
+        ? `${product.convertedQty.toFixed(2)} ${product.unitType || 'oz'}`
         : product.size;
     let uStr =
       product.pricePerUnit != null
-        ? `$${product.pricePerUnit.toFixed(2)}/oz`
+        ? `$${product.pricePerUnit.toFixed(2)}/${product.unitType || 'oz'}`
         : product.unit;
     const cost = monthlyCost(itemName, product);
     const costStr = cost != null ? ` - $${cost.toFixed(2)}/mo` : '';

--- a/scrapers/stopandshop.js
+++ b/scrapers/stopandshop.js
@@ -35,6 +35,28 @@ export function scrapeStopAndShop() {
     unit: 1
   };
 
+  const COUNT_UNITS = new Set([
+    'ea',
+    'ct',
+    'pkg',
+    'box',
+    'can',
+    'bag',
+    'bottle',
+    'stick',
+    'roll',
+    'bar',
+    'pouch',
+    'jar',
+    'packet',
+    'sleeve',
+    'slice',
+    'piece',
+    'tube',
+    'tray',
+    'unit'
+  ]);
+
   const products = [];
   const tiles = document.querySelectorAll('li.tile.product-cell.product-grid-cell');
   tiles.forEach(tile => {
@@ -94,7 +116,7 @@ export function scrapeStopAndShop() {
         unitType = m[3].toLowerCase().replace(/\s+/g, '');
         if (unitType === 'floz') unitType = 'oz';
         const factor = UNIT_FACTORS[unitType];
-        if (factor) {
+        if (factor && !COUNT_UNITS.has(unitType)) {
           pricePerUnit = pricePerUnit / factor;
           unitType = 'oz';
         }
@@ -104,11 +126,19 @@ export function scrapeStopAndShop() {
     if (sizeQty != null && sizeUnit) {
       const factor = UNIT_FACTORS[sizeUnit.toLowerCase()];
       if (factor) {
-        convertedQty = sizeQty * factor;
-        if (priceNumber != null && pricePerUnit == null) {
-          const totalConverted = convertedQty * packCount;
-          pricePerUnit = priceNumber / totalConverted;
-          unitType = 'oz';
+        if (!COUNT_UNITS.has(sizeUnit.toLowerCase())) {
+          convertedQty = sizeQty * factor;
+          if (priceNumber != null && pricePerUnit == null) {
+            const totalConverted = convertedQty * packCount;
+            pricePerUnit = priceNumber / totalConverted;
+            unitType = 'oz';
+          }
+        } else {
+          unitType = sizeUnit.toLowerCase();
+          if (priceNumber != null && pricePerUnit == null) {
+            const totalCount = sizeQty * packCount;
+            pricePerUnit = priceNumber / totalCount;
+          }
         }
       }
     }

--- a/scrapers/walmart.js
+++ b/scrapers/walmart.js
@@ -34,6 +34,28 @@ export function scrapeWalmart() {
     unit: 1
   };
 
+  const COUNT_UNITS = new Set([
+    'ea',
+    'ct',
+    'pkg',
+    'box',
+    'can',
+    'bag',
+    'bottle',
+    'stick',
+    'roll',
+    'bar',
+    'pouch',
+    'jar',
+    'packet',
+    'sleeve',
+    'slice',
+    'piece',
+    'tube',
+    'tray',
+    'unit'
+  ]);
+
   const products = [];
   const tiles = document.querySelectorAll('[data-testid="list-view"] > div');
   tiles.forEach((tile, i) => {
@@ -55,13 +77,24 @@ export function scrapeWalmart() {
       sizeUnit = sizeMatch[2].replace(/\s+/g, '');
       const factor = UNIT_FACTORS[sizeUnit.toLowerCase()];
       if (factor) {
-        convertedQty = sizeQty * factor;
-        unitType = 'oz';
-        if (price) {
-          const p = parseFloat(price.replace(/[^0-9.]/g, ''));
-          if (!isNaN(p)) {
-            const totalConverted = convertedQty * packCount;
-            pricePerUnit = p / totalConverted;
+        if (!COUNT_UNITS.has(sizeUnit.toLowerCase())) {
+          convertedQty = sizeQty * factor;
+          unitType = 'oz';
+          if (price) {
+            const p = parseFloat(price.replace(/[^0-9.]/g, ''));
+            if (!isNaN(p)) {
+              const totalConverted = convertedQty * packCount;
+              pricePerUnit = p / totalConverted;
+            }
+          }
+        } else {
+          unitType = sizeUnit.toLowerCase();
+          if (price) {
+            const p = parseFloat(price.replace(/[^0-9.]/g, ''));
+            if (!isNaN(p)) {
+              const totalCount = sizeQty * packCount;
+              pricePerUnit = p / totalCount;
+            }
           }
         }
       }
@@ -76,7 +109,7 @@ export function scrapeWalmart() {
         pricePerUnit = priceVal / qty;
         unitType = match[3].toLowerCase();
         const factor = UNIT_FACTORS[unitType];
-        if (factor) {
+        if (factor && !COUNT_UNITS.has(unitType)) {
           pricePerUnit = pricePerUnit / factor;
           unitType = 'oz';
         }

--- a/shoppingList.js
+++ b/shoppingList.js
@@ -42,8 +42,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         li.appendChild(img);
         const span = document.createElement('span');
         let pStr = it.product?.priceNumber != null ? `$${it.product.priceNumber.toFixed(2)}` : it.product?.price || '';
-        let qStr = it.product?.convertedQty != null ? `${it.product.convertedQty.toFixed(2)} oz` : it.product?.size || '';
-        let uStr = it.product?.pricePerUnit != null ? `$${it.product.pricePerUnit.toFixed(2)}/oz` : it.product?.unit || '';
+        let qStr =
+          it.product?.convertedQty != null
+            ? `${it.product.convertedQty.toFixed(2)} ${it.product.unitType || 'oz'}`
+            : it.product?.size || '';
+        let uStr =
+          it.product?.pricePerUnit != null
+            ? `$${it.product.pricePerUnit.toFixed(2)}/${it.product.unitType || 'oz'}`
+            : it.product?.unit || '';
         const amt = it.amount != null ? `${it.amount.toFixed(2)} ${it.unit}` : '';
         span.textContent = `${it.item} - ${it.product?.name || ''} - ${pStr} - ${qStr} - ${uStr} - ${amt}`;
         li.appendChild(span);


### PR DESCRIPTION
## Summary
- avoid converting count-based units like `ea` or `ct` to ounces in Walmart and Stop & Shop scrapers
- keep unit type when computing price per unit
- show price/unit with the detected unit instead of always `/oz`

## Testing
- `node --check scrapers/walmart.js`
- `node --check scrapers/stopandshop.js`
- `node --check item.js`
- `node --check popup.js`
- `node --check shoppingList.js`


------
https://chatgpt.com/codex/tasks/task_e_68544356473c8329a4351b2daef3399f