### PR TITLE
Support 'pk' labels in pack count

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -259,17 +259,17 @@ async function loadCommitData(itemName) {
 }
 
 function getPackCount(product) {
-  let m = product?.name?.match(/(\d+)\s*(?:pack|ct|count)/i);
+  let m = product?.name?.match(/(\d+)\s*(?:pk|pack|ct|count)/i);
   if (!m && product?.size) {
     m = product.size.match(/pack\s*of\s*(\d+)/i);
     if (!m) {
-      m = product.size.match(/(\d+)\s*(?:pack|ct|count)/i);
+      m = product.size.match(/(\d+)\s*(?:pk|pack|ct|count)/i);
     }
   }
   if (!m && product?.unit) {
     m = product.unit.match(/pack\s*of\s*(\d+)/i);
     if (!m) {
-      m = product.unit.match(/(\d+)\s*(?:pack|ct|count)/i);
+      m = product.unit.match(/(\d+)\s*(?:pk|pack|ct|count)/i);
     }
   }
   return m ? parseInt(m[1], 10) : 1;

--- a/scrapeResults.js
+++ b/scrapeResults.js
@@ -24,17 +24,17 @@ let needsData = [];
 let consumptionMap = new Map();
 
 function getPackCount(product) {
-  let m = product?.name?.match(/(\d+)\s*(?:pack|ct|count)/i);
+  let m = product?.name?.match(/(\d+)\s*(?:pk|pack|ct|count)/i);
   if (!m && product?.size) {
     m = product.size.match(/pack\s*of\s*(\d+)/i);
     if (!m) {
-      m = product.size.match(/(\d+)\s*(?:pack|ct|count)/i);
+      m = product.size.match(/(\d+)\s*(?:pk|pack|ct|count)/i);
     }
   }
   if (!m && product?.unit) {
     m = product.unit.match(/pack\s*of\s*(\d+)/i);
     if (!m) {
-      m = product.unit.match(/(\d+)\s*(?:pack|ct|count)/i);
+      m = product.unit.match(/(\d+)\s*(?:pk|pack|ct|count)/i);
     }
   }
   return m ? parseInt(m[1], 10) : 1;


### PR DESCRIPTION
## Summary
- update scrapeResults.js and popup.js to detect `pk` in pack count regexes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685446ec51608329a74458297da691ad