### PR TITLE
Fix pack count detection for hyphenated sizes

### DIFF
--- a/item.js
+++ b/item.js
@@ -83,7 +83,8 @@ function getPackCount(product) {
     const s = sanitize(str);
     return (
       s.match(/(\d+)\s*[-\u2011\u2012\u2013\u2014]?\s*(?:pack|pk|ct|count)/i) ||
-      s.match(/pack\s*of\s*(\d+)/i)
+      s.match(/pack\s*of\s*(\d+)/i) ||
+      s.match(/(\d+)\s*[-x\u00d7]\s*\d+/i)
     );
   };
 

--- a/scrapeResults.js
+++ b/scrapeResults.js
@@ -25,16 +25,25 @@ let consumptionMap = new Map();
 
 function getPackCount(product) {
   let m = product?.name?.match(/(\d+)\s*(?:pk|pack|ct|count)/i);
+  if (!m) {
+    m = product?.name?.match(/(\d+)\s*[-x\u00d7]\s*\d+/i);
+  }
   if (!m && product?.size) {
     m = product.size.match(/pack\s*of\s*(\d+)/i);
     if (!m) {
       m = product.size.match(/(\d+)\s*(?:pk|pack|ct|count)/i);
+      if (!m) {
+        m = product.size.match(/(\d+)\s*[-x\u00d7]\s*\d+/i);
+      }
     }
   }
   if (!m && product?.unit) {
     m = product.unit.match(/pack\s*of\s*(\d+)/i);
     if (!m) {
       m = product.unit.match(/(\d+)\s*(?:pk|pack|ct|count)/i);
+      if (!m) {
+        m = product.unit.match(/(\d+)\s*[-x\u00d7]\s*\d+/i);
+      }
     }
   }
   return m ? parseInt(m[1], 10) : 1;


### PR DESCRIPTION
## Summary
- detect pack counts written with `-` or `x`
- apply same logic in item page and scrape results calculations

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68545a6aee0c8329acac44c655f88654