### PR TITLE
Add collapsible category sections

### DIFF
--- a/consumed.html
+++ b/consumed.html
@@ -14,6 +14,7 @@
     .category-header {
       border-top: 1px solid #ccc;
       margin-top: 10px;
+      cursor: pointer;
     }
   </style>
 </head>

--- a/coupon.html
+++ b/coupon.html
@@ -12,6 +12,7 @@
     .category-header {
       border-top: 1px solid #ccc;
       margin-top: 10px;
+      cursor: pointer;
     }
   </style>
 </head>

--- a/editCategory.html
+++ b/editCategory.html
@@ -10,6 +10,7 @@
     .category-header {
       border-top: 1px solid #ccc;
       margin-top: 10px;
+      cursor: pointer;
     }
   </style>
 </head>

--- a/editPlan.html
+++ b/editPlan.html
@@ -10,6 +10,7 @@
     .category-header {
       border-top: 1px solid #ccc;
       margin-top: 10px;
+      cursor: pointer;
     }
   </style>
 </head>

--- a/expiration.html
+++ b/expiration.html
@@ -10,6 +10,7 @@
     .category-header {
       border-top: 1px solid #ccc;
       margin-top: 10px;
+      cursor: pointer;
     }
   </style>
 </head>

--- a/inventory.html
+++ b/inventory.html
@@ -10,6 +10,7 @@
     .category-header {
       border-top: 1px solid #ccc;
       margin-top: 10px;
+      cursor: pointer;
     }
   </style>
 </head>

--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -170,17 +170,35 @@ function buildGrid(items) {
   grid.appendChild(header);
 
   let lastCat = null;
+  let headerRow = null;
+  let itemRows = [];
+
+  function finalizeHeader() {
+    if (!headerRow) return;
+    const th = headerRow.querySelector('.category-header');
+    th.style.cursor = 'pointer';
+    th.addEventListener('click', () => {
+      const hidden = headerRow.dataset.hidden === 'true';
+      headerRow.dataset.hidden = hidden ? 'false' : 'true';
+      itemRows.forEach(r => {
+        r.style.display = hidden ? '' : 'none';
+      });
+    });
+  }
+
   items.forEach(item => {
     const cat = item.category || 'Other';
     if (cat !== lastCat) {
+      finalizeHeader();
       lastCat = cat;
-      const catRow = document.createElement('tr');
+      headerRow = document.createElement('tr');
       const thCat = document.createElement('th');
       thCat.colSpan = 53;
       thCat.className = 'category-header';
       thCat.textContent = cat;
-      catRow.appendChild(thCat);
-      grid.appendChild(catRow);
+      headerRow.appendChild(thCat);
+      grid.appendChild(headerRow);
+      itemRows = [];
     }
     const overrides = {};
     if (item.overrideWeeks) Object.assign(overrides, item.overrideWeeks);
@@ -198,7 +216,9 @@ function buildGrid(items) {
       row.appendChild(td);
     });
     grid.appendChild(row);
+    itemRows.push(row);
   });
+  finalizeHeader();
   return grid;
 }
 

--- a/popup.html
+++ b/popup.html
@@ -22,6 +22,7 @@
     .category-header {
       border-top: 1px solid #ccc;
       margin-top: 10px;
+      cursor: pointer;
     }
   </style>
 </head>

--- a/removeItem.html
+++ b/removeItem.html
@@ -10,6 +10,7 @@
     .category-header {
       border-top: 1px solid #ccc;
       margin-top: 10px;
+      cursor: pointer;
     }
   </style>
 </head>

--- a/uomChange.html
+++ b/uomChange.html
@@ -12,6 +12,7 @@
     .category-header {
       border-top: 1px solid #ccc;
       text-align: left;
+      cursor: pointer;
     }
   </style>
 </head>

--- a/uomChange.js
+++ b/uomChange.js
@@ -90,6 +90,7 @@ function addCategoryRow(tbody, cat) {
   th.textContent = cat;
   tr.appendChild(th);
   tbody.appendChild(tr);
+  return tr;
 }
 
 async function init() {
@@ -104,19 +105,38 @@ async function init() {
   function render() {
     tbody.innerHTML = '';
     let lastCat = null;
+    let headerRow = null;
+    let itemRows = [];
     const arr = filterText
       ? allNeeds.filter(n => n.name.toLowerCase().includes(filterText))
       : allNeeds;
+    function finalizeHeader() {
+      if (!headerRow) return;
+      const th = headerRow.querySelector('.category-header');
+      th.style.cursor = 'pointer';
+      th.addEventListener('click', () => {
+        const hidden = headerRow.dataset.hidden === 'true';
+        headerRow.dataset.hidden = hidden ? 'false' : 'true';
+        itemRows.forEach(r => {
+          r.style.display = hidden ? '' : 'none';
+        });
+      });
+    }
+
     arr.forEach(n => {
       const cat = n.category || 'Other';
       if (cat !== lastCat) {
+        finalizeHeader();
         lastCat = cat;
-        addCategoryRow(tbody, cat);
+        headerRow = addCategoryRow(tbody, cat);
+        itemRows = [];
       }
       const row = buildRow(n);
       rows.push(row);
+      itemRows.push(row.tr);
       tbody.appendChild(row.tr);
     });
+    finalizeHeader();
   }
 
   render();

--- a/utils/sortByCategory.js
+++ b/utils/sortByCategory.js
@@ -11,16 +11,37 @@ export function sortItemsByCategory(arr) {
 
 export function renderItemsWithCategoryHeaders(items, container, renderFn) {
   let lastCat = null;
+  let header = null;
+  let nodes = [];
+
+  function finalizeHeader() {
+    if (!header) return;
+    header.style.cursor = 'pointer';
+    header.addEventListener('click', () => {
+      const hidden = header.dataset.hidden === 'true';
+      header.dataset.hidden = hidden ? 'false' : 'true';
+      nodes.forEach(n => {
+        n.style.display = hidden ? '' : 'none';
+      });
+    });
+  }
+
   items.forEach(item => {
     const cat = item.category || 'Other';
     if (cat !== lastCat) {
+      finalizeHeader();
       lastCat = cat;
-      const header = document.createElement('h3');
+      header = document.createElement('h3');
       header.className = 'category-header';
       header.textContent = cat;
+      nodes = [];
       container.appendChild(header);
     }
     const node = renderFn(item);
-    if (node) container.appendChild(node);
+    if (node) {
+      nodes.push(node);
+      container.appendChild(node);
+    }
   });
+  finalizeHeader();
 }


### PR DESCRIPTION
## Summary
- make category headers clickable in popup windows
- support collapsing rows in unit-of-measure page
- allow hiding inventory timeline categories
- show pointer cursor on category headers

## Testing
- `node --check utils/sortByCategory.js`
- `node --check uomChange.js`
- `node --check inventoryTimeline.js`

------
https://chatgpt.com/codex/tasks/task_e_68555a5602b48329af3d2b02d70f5ada