### PR TITLE
Fix category header toggle in inventory timeline

### DIFF
--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -173,14 +173,15 @@ function buildGrid(items) {
   let headerRow = null;
   let itemRows = [];
 
-  function finalizeHeader() {
-    if (!headerRow) return;
-    const th = headerRow.querySelector('.category-header');
+  function finalizeHeader(row, rows) {
+    if (!row) return;
+    const th = row.querySelector('.category-header');
     th.style.cursor = 'pointer';
+    const associatedRows = rows.slice();
     th.addEventListener('click', () => {
-      const hidden = headerRow.dataset.hidden === 'true';
-      headerRow.dataset.hidden = hidden ? 'false' : 'true';
-      itemRows.forEach(r => {
+      const hidden = row.dataset.hidden === 'true';
+      row.dataset.hidden = hidden ? 'false' : 'true';
+      associatedRows.forEach(r => {
         r.style.display = hidden ? '' : 'none';
       });
     });
@@ -189,7 +190,7 @@ function buildGrid(items) {
   items.forEach(item => {
     const cat = item.category || 'Other';
     if (cat !== lastCat) {
-      finalizeHeader();
+      finalizeHeader(headerRow, itemRows);
       lastCat = cat;
       headerRow = document.createElement('tr');
       const thCat = document.createElement('th');
@@ -218,7 +219,7 @@ function buildGrid(items) {
     grid.appendChild(row);
     itemRows.push(row);
   });
-  finalizeHeader();
+  finalizeHeader(headerRow, itemRows);
   return grid;
 }
 


### PR DESCRIPTION
## Summary
- fix collapse logic for inventory timeline headers by capturing rows in closures

## Testing
- `node --check inventoryTimeline.js`


------
https://chatgpt.com/codex/tasks/task_e_685562d69bd88329b9218e31698716b3