### PR TITLE
Hide items under category headers by default

### DIFF
--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -175,6 +175,10 @@ function buildGrid(items) {
 
   function finalizeHeader(row, rows) {
     if (!row) return;
+    row.dataset.hidden = 'true';
+    rows.forEach(r => {
+      r.style.display = 'none';
+    });
     const th = row.querySelector('.category-header');
     th.style.cursor = 'pointer';
     const associatedRows = rows.slice();

--- a/uomChange.js
+++ b/uomChange.js
@@ -112,6 +112,10 @@ async function init() {
       : allNeeds;
     function finalizeHeader() {
       if (!headerRow) return;
+      headerRow.dataset.hidden = 'true';
+      itemRows.forEach(r => {
+        r.style.display = 'none';
+      });
       const th = headerRow.querySelector('.category-header');
       th.style.cursor = 'pointer';
       th.addEventListener('click', () => {

--- a/utils/sortByCategory.js
+++ b/utils/sortByCategory.js
@@ -18,6 +18,10 @@ export function renderItemsWithCategoryHeaders(items, container, renderFn) {
     if (!header) return;
     const curHeader = header;
     const curNodes = [...nodes];
+    curHeader.dataset.hidden = 'true';
+    curNodes.forEach(n => {
+      n.style.display = 'none';
+    });
     curHeader.style.cursor = 'pointer';
     curHeader.addEventListener('click', () => {
       const hidden = curHeader.dataset.hidden === 'true';


### PR DESCRIPTION
## Summary
- default hidden state for all category headers in `sortByCategory.js`
- hide item rows by default in UOM change table
- hide grid rows by default in inventory timeline

## Testing
- `node --check utils/sortByCategory.js && node --check uomChange.js && node --check inventoryTimeline.js`

------
https://chatgpt.com/codex/tasks/task_e_68556470c28483299967e438fb31da10