### PR TITLE
Preserve header visibility

### DIFF
--- a/consumed.js
+++ b/consumed.js
@@ -9,6 +9,7 @@ const NEEDS_KEY = 'yearlyNeeds';
 const NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
 
 let filterText = '';
+const headerState = {};
 let allNeeds = [];
 let globalMap;
 let globalHistory;
@@ -194,7 +195,7 @@ async function init() {
       const item = globalMap.get(n.name);
       const weekly = n.total_needed_year ? n.total_needed_year / 52 : 0;
       return createItemRow(item, globalMap, globalHistory, globalOverrides, weekly);
-    });
+    }, headerState);
   }
 
   render();

--- a/coupon.js
+++ b/coupon.js
@@ -7,6 +7,7 @@ import {
 const NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json';
 
 let filterText = '';
+const headerState = {};
 let allNeeds = [];
 let container;
 let couponsMap;
@@ -180,7 +181,12 @@ async function init() {
     const arr = filterText
       ? allNeeds.filter(n => n.name.toLowerCase().includes(filterText))
       : allNeeds;
-    renderItemsWithCategoryHeaders(arr, container, n => createRow(n, couponsMap));
+    renderItemsWithCategoryHeaders(
+      arr,
+      container,
+      n => createRow(n, couponsMap),
+      headerState
+    );
   }
 
   render();

--- a/editCategory.js
+++ b/editCategory.js
@@ -5,6 +5,7 @@ const NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json
 const NEEDS_KEY = 'yearlyNeeds';
 
 let filterText = '';
+const headerState = {};
 let allNeeds = [];
 let container;
 
@@ -64,7 +65,12 @@ async function init() {
     const arr = filterText
       ? allNeeds.filter(n => n.name.toLowerCase().includes(filterText))
       : allNeeds;
-    renderItemsWithCategoryHeaders(arr, container, item => createRow(item, needs));
+    renderItemsWithCategoryHeaders(
+      arr,
+      container,
+      item => createRow(item, needs),
+      headerState
+    );
   }
 
   render();

--- a/editPlan.js
+++ b/editPlan.js
@@ -5,6 +5,7 @@ const NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json
 const CONS_PATH = 'Required for grocery app/monthly_consumption_table.json';
 
 let filterText = '';
+const headerState = {};
 let allNeeds = [];
 let needsMap;
 let consMap;
@@ -103,8 +104,11 @@ async function init() {
       ? allNeeds.filter(n => n.name.toLowerCase().includes(filterText))
       : allNeeds;
     container.innerHTML = '';
-    renderItemsWithCategoryHeaders(arr, container, item =>
-      createRow(item, needsMap, consMap, needs, consumption)
+    renderItemsWithCategoryHeaders(
+      arr,
+      container,
+      item => createRow(item, needsMap, consMap, needs, consumption),
+      headerState
     );
   }
 

--- a/expiration.js
+++ b/expiration.js
@@ -9,6 +9,7 @@ const NEEDS_PATH = 'Required for grocery app/yearly_needs_with_manual_flags.json
 const EXPIRATION_PATH = 'Required for grocery app/expiration_times_full.json';
 
 let filterText = '';
+const headerState = {};
 let allNeeds = [];
 let container;
 
@@ -89,8 +90,11 @@ async function init() {
     const arr = filterText
       ? allNeeds.filter(n => n.name.toLowerCase().includes(filterText))
       : allNeeds;
-    renderItemsWithCategoryHeaders(arr, container, n =>
-      createRow(n, expMap, expiration)
+    renderItemsWithCategoryHeaders(
+      arr,
+      container,
+      n => createRow(n, expMap, expiration),
+      headerState
     );
   }
 

--- a/inventory.js
+++ b/inventory.js
@@ -115,6 +115,7 @@ let expirationData = [];
 let categoryMap = new Map();
 let needsData = [];
 let filterText = '';
+const headerState = {};
 
 function renderWeek(week) {
   const container = document.getElementById('inventory');
@@ -135,7 +136,7 @@ function renderWeek(week) {
   renderItemsWithCategoryHeaders(filtered, container, item => {
     const amt = stockForWeek.get(item.name) || 0;
     return createItemRow(item.name, amt, item.unit, purchasesMap, week);
-  });
+  }, headerState);
 }
 
 async function init() {

--- a/popup.js
+++ b/popup.js
@@ -101,6 +101,7 @@ let consumedYearData = [];
 let purchasesData = {};
 let hideZeroItems = false;
 let filterText = '';
+const headerState = {};
 
 function getFinal(itemName) {
   const key = `final_${encodeURIComponent(itemName)}`;
@@ -174,7 +175,7 @@ async function init() {
     li.appendChild(finalImg);
     finalMap.set(item.name, { li, btn, span: finalSpan, img: finalImg });
     return li;
-  });
+  }, headerState);
 }
 
 init();

--- a/removeItem.js
+++ b/removeItem.js
@@ -12,6 +12,7 @@ const STORE_SELECTION_PATH = 'Required for grocery app/store_selection_stopandsh
 const STORE_SELECTION_KEY = 'storeSelections';
 
 let filterText = '';
+const headerState = {};
 let allItems = [];
 let ul;
 
@@ -174,7 +175,7 @@ async function init() {
     const arr = filterText
       ? allItems.filter(it => it.name.toLowerCase().includes(filterText))
       : allItems;
-    renderItemsWithCategoryHeaders(arr, ul, it => createListItem(it.name));
+    renderItemsWithCategoryHeaders(arr, ul, it => createListItem(it.name), headerState);
   }
 
   render();

--- a/uomChange.js
+++ b/uomChange.js
@@ -6,6 +6,7 @@ const CONSUMPTION_PATH = 'Required for grocery app/monthly_consumption_table.jso
 const STOCK_PATH = 'Required for grocery app/current_stock_table.json';
 
 let filterText = '';
+const headerState = {};
 let allNeeds = [];
 let tbody;
 
@@ -110,27 +111,30 @@ async function init() {
     const arr = filterText
       ? allNeeds.filter(n => n.name.toLowerCase().includes(filterText))
       : allNeeds;
-    function finalizeHeader() {
-      if (!headerRow) return;
-      headerRow.dataset.hidden = 'true';
-      itemRows.forEach(r => {
-        r.style.display = 'none';
+    function finalizeHeader(cat, row, rowsArr) {
+      if (!row) return;
+      const hidden =
+        headerState[cat] !== undefined ? headerState[cat] : true;
+      row.dataset.hidden = hidden ? 'true' : 'false';
+      rowsArr.forEach(r => {
+        r.style.display = hidden ? 'none' : '';
       });
-      const th = headerRow.querySelector('.category-header');
+      const th = row.querySelector('.category-header');
       th.style.cursor = 'pointer';
       th.addEventListener('click', () => {
-        const hidden = headerRow.dataset.hidden === 'true';
-        headerRow.dataset.hidden = hidden ? 'false' : 'true';
-        itemRows.forEach(r => {
-          r.style.display = hidden ? '' : 'none';
+        const isHidden = row.dataset.hidden === 'true';
+        row.dataset.hidden = isHidden ? 'false' : 'true';
+        rowsArr.forEach(r => {
+          r.style.display = isHidden ? '' : 'none';
         });
+        headerState[cat] = !isHidden;
       });
     }
 
     arr.forEach(n => {
       const cat = n.category || 'Other';
       if (cat !== lastCat) {
-        finalizeHeader();
+        finalizeHeader(lastCat, headerRow, itemRows);
         lastCat = cat;
         headerRow = addCategoryRow(tbody, cat);
         itemRows = [];
@@ -140,7 +144,7 @@ async function init() {
       itemRows.push(row.tr);
       tbody.appendChild(row.tr);
     });
-    finalizeHeader();
+    finalizeHeader(lastCat, headerRow, itemRows);
   }
 
   render();

--- a/utils/sortByCategory.js
+++ b/utils/sortByCategory.js
@@ -9,33 +9,38 @@ export function sortItemsByCategory(arr) {
   });
 }
 
-export function renderItemsWithCategoryHeaders(items, container, renderFn) {
+export function renderItemsWithCategoryHeaders(
+  items,
+  container,
+  renderFn,
+  headerState = {}
+) {
   let lastCat = null;
   let header = null;
   let nodes = [];
 
-  function finalizeHeader() {
-    if (!header) return;
-    const curHeader = header;
-    const curNodes = [...nodes];
-    curHeader.dataset.hidden = 'true';
-    curNodes.forEach(n => {
-      n.style.display = 'none';
+  function finalizeHeader(cat, hdr, nodesForHeader) {
+    if (!hdr) return;
+    const hidden = headerState[cat] !== undefined ? headerState[cat] : true;
+    hdr.dataset.hidden = hidden ? 'true' : 'false';
+    nodesForHeader.forEach(n => {
+      n.style.display = hidden ? 'none' : '';
     });
-    curHeader.style.cursor = 'pointer';
-    curHeader.addEventListener('click', () => {
-      const hidden = curHeader.dataset.hidden === 'true';
-      curHeader.dataset.hidden = hidden ? 'false' : 'true';
-      curNodes.forEach(n => {
-        n.style.display = hidden ? '' : 'none';
+    hdr.style.cursor = 'pointer';
+    hdr.addEventListener('click', () => {
+      const isHidden = hdr.dataset.hidden === 'true';
+      hdr.dataset.hidden = isHidden ? 'false' : 'true';
+      nodesForHeader.forEach(n => {
+        n.style.display = isHidden ? '' : 'none';
       });
+      headerState[cat] = !isHidden;
     });
   }
 
   items.forEach(item => {
     const cat = item.category || 'Other';
     if (cat !== lastCat) {
-      finalizeHeader();
+      finalizeHeader(lastCat, header, nodes);
       lastCat = cat;
       header = document.createElement('h3');
       header.className = 'category-header';
@@ -49,5 +54,5 @@ export function renderItemsWithCategoryHeaders(items, container, renderFn) {
       container.appendChild(node);
     }
   });
-  finalizeHeader();
+  finalizeHeader(lastCat, header, nodes);
 }


### PR DESCRIPTION
## Summary
- maintain state of category headers across refreshes
- default to collapsed if no stored state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855680a12e88329a92f3d22386f7766