### PR TITLE
Add meal button to meal list view

### DIFF
--- a/addMeal.html
+++ b/addMeal.html
@@ -19,7 +19,7 @@
   </style>
 </head>
 <body>
-  <h1>Add Meal</h1>
+  <h1 id="title"></h1>
   <table>
     <thead>
       <tr>

--- a/addMeal.js
+++ b/addMeal.js
@@ -2,8 +2,10 @@ import { loadJSON } from './utils/dataLoader.js';
 import { MEAL_TYPES } from './utils/mealData.js';
 import { calculateAndSaveMealNeeds } from './utils/mealNeedsCalculator.js';
 
-const MEAL_KEY = MEAL_TYPES.lunchDinner.key;
-const MEAL_PATH = MEAL_TYPES.lunchDinner.path;
+const params = new URLSearchParams(location.search);
+const mealType = params.get('type') || 'lunchDinner';
+const { key: MEAL_KEY, path: MEAL_PATH, label } =
+  MEAL_TYPES[mealType] || MEAL_TYPES.lunchDinner;
 const UOM_PATH = 'Required for grocery app/uom_conversion_table.json';
 
 function loadMeals() {
@@ -79,6 +81,8 @@ function anyFilled(row) {
 }
 
 async function init() {
+  const titleEl = document.getElementById('title');
+  if (titleEl) titleEl.textContent = `Add ${label} Meal`;
   const units = await loadUnits();
   const tbody = document.getElementById('mealBody');
   const rows = [];

--- a/mealListView.html
+++ b/mealListView.html
@@ -11,6 +11,7 @@
 </head>
 <body>
   <h1 id="title"></h1>
+  <button id="addMeal">Add Meal</button>
   <table>
     <thead>
       <tr>

--- a/mealListView.js
+++ b/mealListView.js
@@ -149,6 +149,12 @@ function updateInventoryDisplay() {
 
 async function init() {
   document.getElementById('title').textContent = `${label} Meals`;
+  const addBtn = document.getElementById('addMeal');
+  if (addBtn) {
+    addBtn.addEventListener('click', () => {
+      openOrFocusWindow(`addMeal.html?type=${type}`);
+    });
+  }
   const tbody = document.getElementById('mealBody');
   const [meals, stock] = await Promise.all([loadMeals(), loadStock()]);
   inventorySet = new Set(stock.map(s => s.name));


### PR DESCRIPTION
## Summary
- allow Add Meal screen to work with different meal types via query param
- show category heading in Add Meal screen
- add "Add Meal" button to each meal list view
- wire button to open the correct meal type

## Testing
- `node --check mealListView.js`
- `node --check addMeal.js`


------
https://chatgpt.com/codex/tasks/task_e_685c7deb3be8832989d2123bf6744b3a