### PR TITLE
Fix leftover add meal button

### DIFF
--- a/mealPlanner.html
+++ b/mealPlanner.html
@@ -11,7 +11,6 @@
 <body>
   <h1>Meal Planner</h1>
   <button id="openLists">Open Meal Lists</button>
-  <button id="addMeal">Add Meal</button>
   <script type="module" src="mealPlanner.js"></script>
 </body>
 </html>

--- a/mealPlanner.js
+++ b/mealPlanner.js
@@ -4,6 +4,3 @@ document.getElementById('openLists').addEventListener('click', () => {
   openOrFocusWindow('mealListSelect.html');
 });
 
-document.getElementById('addMeal').addEventListener('click', () => {
-  openOrFocusWindow('addMeal.html');
-});


### PR DESCRIPTION
## Summary
- remove the Add Meal button from the main meal planner window
- drop unused event listener

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c7fe647ac8329b345967e92bddda0