### PR TITLE
Fix inventoryTimeline item map typo

### DIFF
--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -102,17 +102,18 @@ function buildItemMap(needs, expiration, stock, consumption, mealMonth) {
     consMap[key] = (consMap[key] || 0) + m.monthly_consumption;
   });
 
-  return needs.map(n => ({
-    name: n.name,
-    category: n.category || '',
-    units_per_purchase: 1,
+  return needs.map(n => {
     const key = normalizeName(n.name);
-    weekly_consumption:
-      (consMap[key] || 0) / WEEKS_PER_MONTH,
-    expiration_weeks: expMap[key] || 52,
-    starting_stock: stockMap[key] || 0,
-    purchases: []
-  }));
+    return {
+      name: n.name,
+      category: n.category || '',
+      units_per_purchase: 1,
+      weekly_consumption: (consMap[key] || 0) / WEEKS_PER_MONTH,
+      expiration_weeks: expMap[key] || 52,
+      starting_stock: stockMap[key] || 0,
+      purchases: []
+    };
+  });
 }
 
 function simulateItem(item, overrides) {


### PR DESCRIPTION
## Summary
- fix malformed object literal in `inventoryTimeline.js`

## Testing
- `node --check inventoryTimeline.js`

------
https://chatgpt.com/codex/tasks/task_e_685d9631fadc8329b922bb41f861cd4b