### PR TITLE
Fix meal checkbox logic

### DIFF
--- a/addMeal.js
+++ b/addMeal.js
@@ -140,7 +140,7 @@ async function init() {
     }));
 
     const meals = await loadMeals();
-    meals.push({ name: mealName, ingredients, multiplier: 1 });
+    meals.push({ name: mealName, ingredients, people: 1 });
     await saveMeals(meals);
     await calculateAndSaveMealNeeds();
     window.close();

--- a/mealListView.js
+++ b/mealListView.js
@@ -56,7 +56,7 @@ function saveMeals(arr) {
 function createRows(meal, arr) {
   const rows = [];
   const ingredients = meal.ingredients || [];
-  if (meal.multiplier === undefined) meal.multiplier = meal.active === false ? 0 : 1;
+  if (meal.people === undefined) meal.people = meal.active === false ? 0 : 1;
 
   ingredients.forEach((ing, idx) => {
     const tr = document.createElement('tr');
@@ -67,10 +67,10 @@ function createRows(meal, arr) {
       for (let i = 0; i < 5; i++) {
         const chk = document.createElement('input');
         chk.type = 'checkbox';
-        chk.checked = i < (meal.multiplier || 1);
+        chk.checked = i < (meal.people || meal.multiplier || 1);
         chk.addEventListener('change', async () => {
-          meal.multiplier = Array.from(chks).filter(c => c.checked).length;
-          meal.active = meal.multiplier > 0;
+          meal.people = Array.from(chks).filter(c => c.checked).length;
+          meal.active = meal.people > 0;
           await saveMeals(arr);
           await calculateAndSaveMealNeeds();
         });
@@ -120,10 +120,10 @@ function createRows(meal, arr) {
     for (let i = 0; i < 5; i++) {
       const chk = document.createElement('input');
       chk.type = 'checkbox';
-      chk.checked = i < (meal.multiplier || 1);
+      chk.checked = i < (meal.people || meal.multiplier || 1);
       chk.addEventListener('change', async () => {
-        meal.multiplier = Array.from(chks).filter(c => c.checked).length;
-        meal.active = meal.multiplier > 0;
+        meal.people = Array.from(chks).filter(c => c.checked).length;
+        meal.active = meal.people > 0;
         await saveMeals(arr);
         await calculateAndSaveMealNeeds();
       });

--- a/utils/mealNeedsCalculator.js
+++ b/utils/mealNeedsCalculator.js
@@ -34,9 +34,9 @@ export async function calculateAndSaveMealNeeds() {
   const nameLookup = {};
   for (const type of Object.keys(MEAL_TYPES)) {
     const meals = await loadMeals(type);
-    const active = meals.filter(m => (m.multiplier || 0) > 0);
+    const active = meals.filter(m => (m.people ?? m.multiplier ?? 1) > 0);
     if (!active.length) continue;
-    const totalCount = active.reduce((sum, m) => sum + (m.multiplier || 1), 0);
+    const totalCount = active.length;
     const baseSpots = calculateMonthlyMealSpots(
       DEFAULT_MEALS_PER_DAY[type],
       1,
@@ -44,7 +44,8 @@ export async function calculateAndSaveMealNeeds() {
       totalCount
     );
     active.forEach(meal => {
-      const mealSpots = baseSpots * (meal.multiplier || 1);
+      const people = meal.people ?? meal.multiplier ?? 1;
+      const mealSpots = baseSpots * people;
       (meal.ingredients || []).forEach(ing => {
         const serving = parseAmount(ing.serving_size || ing.amount);
         if (!serving) return;


### PR DESCRIPTION
## Summary
- interpret checkboxes in meal list as number of people eating
- update meal needs calculator to use new `people` count
- default new meals to `people: 1`

## Testing
- `node --check mealListView.js`
- `node --check addMeal.js`
- `node --check utils/mealNeedsCalculator.js`


------
https://chatgpt.com/codex/tasks/task_e_685da9cb79248329bf1a6ce6365536e5