### PR TITLE
Add user management for meal planner

### DIFF
--- a/mealPlanner.js
+++ b/mealPlanner.js
@@ -4,3 +4,7 @@ document.getElementById('openLists').addEventListener('click', () => {
   openOrFocusWindow('mealListSelect.html');
 });
 
+document.getElementById('openUsers').addEventListener('click', () => {
+  openOrFocusWindow('users.html');
+});
+

--- a/users.html
+++ b/users.html
@@ -2,16 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Meal Planner</title>
+  <title>Users</title>
   <style>
     body { font-family: Arial, sans-serif; width: 300px; }
     button { width: 100%; margin: 5px 0; }
+    #mealList { margin-top: 10px; }
   </style>
 </head>
 <body>
-  <h1>Meal Planner</h1>
-  <button id="openLists">Open Meal Lists</button>
-  <button id="openUsers">Users</button>
-  <script type="module" src="mealPlanner.js"></script>
+  <h1>Users</h1>
+  <div id="userButtons"></div>
+  <ul id="mealList"></ul>
+  <script type="module" src="users.js"></script>
 </body>
 </html>

--- a/users.js
+++ b/users.js
@@ -1,0 +1,102 @@
+import { loadUsers, saveUsers } from './utils/userData.js';
+import { MEAL_TYPES } from './utils/mealData.js';
+import { loadJSON } from './utils/dataLoader.js';
+
+const btnContainer = document.getElementById('userButtons');
+const mealList = document.getElementById('mealList');
+
+let users = [];
+let addInput = null;
+let saveBtn = null;
+let addBtn = null;
+
+function renderButtons() {
+  btnContainer.innerHTML = '';
+  users.forEach((name, idx) => {
+    const btn = document.createElement('button');
+    btn.textContent = name;
+    btn.addEventListener('click', () => showMeals(idx));
+    btnContainer.appendChild(btn);
+  });
+  addBtn = document.createElement('button');
+  addBtn.textContent = 'Add User';
+  addBtn.addEventListener('click', () => startAddUser());
+  btnContainer.appendChild(addBtn);
+}
+
+function startAddUser() {
+  if (addInput) return;
+  addInput = document.createElement('input');
+  addInput.type = 'text';
+  addInput.placeholder = 'New user name';
+  saveBtn = document.createElement('button');
+  saveBtn.textContent = 'Save';
+  saveBtn.style.display = 'none';
+  addInput.addEventListener('input', () => {
+    saveBtn.style.display = addInput.value.trim() ? 'inline' : 'none';
+  });
+  saveBtn.addEventListener('click', saveNewUser);
+  btnContainer.insertBefore(addInput, addBtn);
+  btnContainer.insertBefore(saveBtn, addBtn);
+}
+
+async function saveNewUser() {
+  const val = addInput.value.trim();
+  if (!val) return;
+  users.push(val);
+  await saveUsers(users);
+  addInput.remove();
+  saveBtn.remove();
+  addInput = null;
+  saveBtn = null;
+  renderButtons();
+}
+
+function loadMeals(type) {
+  const { key, path } = MEAL_TYPES[type];
+  return new Promise(async resolve => {
+    chrome.storage.local.get(key, async data => {
+      if (data[key]) {
+        resolve(data[key]);
+      } else {
+        const arr = await loadJSON(path);
+        resolve(arr);
+      }
+    });
+  });
+}
+
+async function loadAllMeals() {
+  const all = [];
+  for (const type of Object.keys(MEAL_TYPES)) {
+    const meals = await loadMeals(type);
+    all.push(...meals);
+  }
+  return all;
+}
+
+async function showMeals(userIndex) {
+  const meals = await loadAllMeals();
+  mealList.innerHTML = '';
+  meals.forEach(m => {
+    let used = false;
+    if (Array.isArray(m.users)) {
+      used = m.users[userIndex];
+    } else if (userIndex === 0) {
+      const people = m.people ?? m.multiplier ?? (m.active === false ? 0 : 1);
+      used = people > 0;
+    }
+    if (used) {
+      const li = document.createElement('li');
+      li.textContent = m.name || '';
+      mealList.appendChild(li);
+    }
+  });
+}
+
+async function init() {
+  users = await loadUsers();
+  renderButtons();
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/utils/userData.js
+++ b/utils/userData.js
@@ -1,0 +1,18 @@
+export function loadUsers() {
+  return new Promise(resolve => {
+    chrome.storage.local.get('users', data => {
+      if (Array.isArray(data.users) && data.users.length) {
+        resolve(data.users);
+      } else {
+        const defaultUsers = Array.from({ length: 5 }, (_, i) => `User ${i + 1}`);
+        resolve(defaultUsers);
+      }
+    });
+  });
+}
+
+export function saveUsers(arr) {
+  return new Promise(resolve => {
+    chrome.storage.local.set({ users: arr }, () => resolve());
+  });
+}


### PR DESCRIPTION
## Summary
- label meal checkboxes by user
- add Users button to meal planner
- create Users management window with ability to add new users
- track user list in storage via new utility

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685fe96cf75083298c9fa21b8b045088