### PR TITLE
Add reset option in Meal Chooser

### DIFF
--- a/mealChooser.html
+++ b/mealChooser.html
@@ -21,6 +21,7 @@
     </select>
   </label>
   <div id="remaining"></div>
+  <button id="resetBtn">Reset</button>
   <div id="mealButtons"></div>
   <script type="module" src="mealChooser.js"></script>
 </body>

--- a/mealChooser.js
+++ b/mealChooser.js
@@ -69,6 +69,7 @@ async function init() {
   const categorySelect = document.getElementById('categorySelect');
   const mealButtons = document.getElementById('mealButtons');
   const remainingDiv = document.getElementById('remaining');
+  const resetBtn = document.getElementById('resetBtn');
 
   const users = await loadUsers();
   let slots = await loadMealSlots();
@@ -127,6 +128,11 @@ async function init() {
   }
 
   renderUserButtons();
+  resetBtn.addEventListener('click', async () => {
+    slots = { week: getCurrentWeek(), users: {} };
+    await saveMealSlots(slots);
+    renderMeals();
+  });
   categorySelect.addEventListener('change', renderMeals);
   renderMeals();
 }


### PR DESCRIPTION
## Summary
- add a Reset button on the Meal Chooser page
- implement reset logic to clear meal slots

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685ff7f6f6388329a8dae7c9f9aa19dc