### PR TITLE
Add meal multiplier feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,8 @@ where:
 Multiply the monthly spots by an ingredient's serving size to get the monthly amount needed.
 
 The file `utils/mealMath.js` exposes helpers and a `DEFAULT_MEALS_PER_DAY` object. Lunch and dinner share the `lunchDinner` key. Its default value is `2` (two meals each day), but you can adjust these counts per person in the future.
+
+Use the **Meal Multiplier** button in the inventory tracker to change how many
+times each meal category is eaten per day. The popup shows the current numbers
+for Breakfast, Lunch/Dinner, Snacks, and Desserts. Enter a new value and click
+**Save** to update the multiplier used by the meal math calculations.

--- a/inventoryTimeline.html
+++ b/inventoryTimeline.html
@@ -21,6 +21,7 @@
       <button id="couponBtn">Coupons</button>
       <button id="backupBtn">💾</button>
       <button id="uomChange">UOM Change</button>
+      <button id="mealMultiplier">Meal Multiplier</button>
       <button id="mealPlanner">Meal Planner</button>
     </div>
   </div>

--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -510,6 +510,9 @@ async function init() {
   document.getElementById('uomChange').addEventListener('click', () => {
     openOrFocusWindow('uomChange.html');
   });
+  document.getElementById('mealMultiplier').addEventListener('click', () => {
+    openOrFocusWindow('mealMultiplier.html');
+  });
   document.getElementById('mealPlanner').addEventListener('click', () => {
     openOrFocusWindow('mealPlanner.html');
   });

--- a/mealChooser.js
+++ b/mealChooser.js
@@ -1,5 +1,5 @@
 import { loadUsers } from './utils/userData.js';
-import { MEAL_TYPES, DEFAULT_MEALS_PER_DAY } from './utils/mealData.js';
+import { MEAL_TYPES, DEFAULT_MEALS_PER_DAY, loadMealsPerDay } from './utils/mealData.js';
 import { loadJSON } from './utils/dataLoader.js';
 
 function getCurrentWeek() {
@@ -41,12 +41,6 @@ function saveMealSlots(slots) {
   });
 }
 
-function weeklySpotsPerUser(category, userCount) {
-  const perDay = DEFAULT_MEALS_PER_DAY[category] || 0;
-  const yearlySpots = perDay * (userCount * 7) * 52;
-  const perPersonYear = yearlySpots / userCount;
-  return perPersonYear / 52;
-}
 
 function usesMeal(meal, idx, userNames) {
   if (Array.isArray(meal.users)) {
@@ -73,7 +67,15 @@ async function init() {
 
   const users = await loadUsers();
   let slots = await loadMealSlots();
+  const mealsPerDay = await loadMealsPerDay();
   let currentUser = 0;
+
+  function weeklySpotsPerUser(category, userCount) {
+    const perDay = mealsPerDay[category] ?? DEFAULT_MEALS_PER_DAY[category] || 0;
+    const yearlySpots = perDay * (userCount * 7) * 52;
+    const perPersonYear = yearlySpots / userCount;
+    return perPersonYear / 52;
+  }
 
   function renderUserButtons() {
     userButtons.innerHTML = '';

--- a/mealMultiplier.html
+++ b/mealMultiplier.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Meal Multiplier</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 300px; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 4px; border-bottom: 1px solid #ccc; }
+    .hidden { display: none; }
+    input[type="number"] { width: 60px; }
+  </style>
+</head>
+<body>
+  <h1>Meal Multiplier</h1>
+  <table>
+    <thead>
+      <tr>
+        <th>Category</th>
+        <th>Per Day</th>
+        <th>New</th>
+        <th>Save</th>
+      </tr>
+    </thead>
+    <tbody id="multiplierBody"></tbody>
+  </table>
+  <script type="module" src="mealMultiplier.js"></script>
+</body>
+</html>

--- a/mealMultiplier.js
+++ b/mealMultiplier.js
@@ -1,0 +1,56 @@
+import { MEAL_TYPES, DEFAULT_MEALS_PER_DAY, loadMealsPerDay, saveMealsPerDay } from './utils/mealData.js';
+
+let data = {};
+
+function buildRow(key, label, tbody) {
+  const tr = document.createElement('tr');
+  const catTd = document.createElement('td');
+  catTd.textContent = label;
+  const curTd = document.createElement('td');
+  curTd.textContent = data[key];
+  const inputTd = document.createElement('td');
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.step = 'any';
+  inputTd.appendChild(input);
+  const saveTd = document.createElement('td');
+  const saveBtn = document.createElement('button');
+  saveBtn.textContent = 'Save';
+  saveBtn.className = 'hidden';
+  saveTd.appendChild(saveBtn);
+
+  function update() {
+    if (input.value.trim()) saveBtn.classList.remove('hidden');
+    else saveBtn.classList.add('hidden');
+  }
+
+  input.addEventListener('input', update);
+  saveBtn.addEventListener('click', async () => {
+    const val = parseFloat(input.value);
+    if (isNaN(val)) return;
+    data[key] = val;
+    await saveMealsPerDay(data);
+    curTd.textContent = val;
+    input.value = '';
+    saveBtn.classList.add('hidden');
+    try { chrome.runtime.sendMessage({ type: 'inventory-updated' }); } catch (_) {}
+  });
+
+  tr.appendChild(catTd);
+  tr.appendChild(curTd);
+  tr.appendChild(inputTd);
+  tr.appendChild(saveTd);
+  tbody.appendChild(tr);
+}
+
+async function init() {
+  data = await loadMealsPerDay();
+  const tbody = document.getElementById('multiplierBody');
+  Object.keys(MEAL_TYPES).forEach(key => {
+    const label = MEAL_TYPES[key].label;
+    if (data[key] === undefined) data[key] = DEFAULT_MEALS_PER_DAY[key];
+    buildRow(key, label, tbody);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/popup.html
+++ b/popup.html
@@ -42,6 +42,7 @@
       <button id="couponBtn">Coupons</button>
       <button id="backupBtn">💾</button>
       <button id="uomChange">UOM Change</button>
+      <button id="mealMultiplier">Meal Multiplier</button>
       <button id="mealChooser">Meal Chooser</button>
       <button id="toggleZero">Hide Zero Qty</button>
     </div>

--- a/popup.js
+++ b/popup.js
@@ -503,6 +503,14 @@ document
   .getElementById('uomChange')
   .addEventListener('click', openUomChange);
 
+function openMealMultiplier() {
+  openOrFocusWindow('mealMultiplier.html');
+}
+
+document
+  .getElementById('mealMultiplier')
+  .addEventListener('click', openMealMultiplier);
+
 function openMealChooser() {
   openOrFocusWindow('mealChooser.html');
 }

--- a/utils/mealData.js
+++ b/utils/mealData.js
@@ -28,3 +28,17 @@ export const DEFAULT_MEALS_PER_DAY = {
   snack: 1,
   dessert: 1
 };
+
+export function loadMealsPerDay() {
+  return new Promise(resolve => {
+    chrome.storage.local.get('mealsPerDay', data => {
+      resolve({ ...DEFAULT_MEALS_PER_DAY, ...(data.mealsPerDay || {}) });
+    });
+  });
+}
+
+export function saveMealsPerDay(obj) {
+  return new Promise(resolve => {
+    chrome.storage.local.set({ mealsPerDay: obj }, () => resolve());
+  });
+}

--- a/utils/mealNeedsCalculator.js
+++ b/utils/mealNeedsCalculator.js
@@ -1,4 +1,4 @@
-import { MEAL_TYPES, DEFAULT_MEALS_PER_DAY } from './mealData.js';
+import { MEAL_TYPES, DEFAULT_MEALS_PER_DAY, loadMealsPerDay } from './mealData.js';
 import { loadJSON } from './dataLoader.js';
 import { calculateMonthlyMealSpots } from './mealMath.js';
 
@@ -30,13 +30,14 @@ function loadMeals(type) {
 
 export async function calculateAndSaveMealNeeds() {
   const monthlyMap = {};
+  const mealsPerDay = await loadMealsPerDay();
   for (const type of Object.keys(MEAL_TYPES)) {
     const meals = await loadMeals(type);
     const active = meals.filter(m => (m.people ?? m.multiplier ?? 1) > 0);
     if (!active.length) continue;
     const totalCount = active.length;
     const baseSpots = calculateMonthlyMealSpots(
-      DEFAULT_MEALS_PER_DAY[type],
+      mealsPerDay[type] ?? DEFAULT_MEALS_PER_DAY[type],
       1,
       7,
       totalCount


### PR DESCRIPTION
## Summary
- make meal multipliers configurable in `utils/mealData.js`
- use saved multipliers in meal calculations
- allow Meal Chooser to read stored meal multipliers
- add Meal Multiplier popup to edit daily meal counts
- link Meal Multiplier from main UIs
- document the feature

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68600590e0ec832995f7c478903e782a