### PR TITLE
Ensure meal planner windows update on new meals

### DIFF
--- a/mealChooser.js
+++ b/mealChooser.js
@@ -138,6 +138,17 @@ async function init() {
   });
   categorySelect.addEventListener('change', renderMeals);
   renderMeals();
+
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local') {
+      if (Object.values(MEAL_TYPES).some(t => changes[t.key])) {
+        renderMeals();
+      }
+      if (changes.users) {
+        location.reload();
+      }
+    }
+  });
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/mealListSelect.js
+++ b/mealListSelect.js
@@ -16,8 +16,9 @@ function loadMeals(type) {
   });
 }
 
-async function init() {
+async function renderButtons() {
   const div = document.getElementById('listButtons');
+  div.innerHTML = '';
   for (const type of Object.keys(MEAL_TYPES)) {
     const meals = await loadMeals(type);
     const active = meals.filter(m => m.active !== false).length;
@@ -28,6 +29,16 @@ async function init() {
     });
     div.appendChild(btn);
   }
+}
+
+async function init() {
+  await renderButtons();
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local') {
+      const changed = Object.values(MEAL_TYPES).some(t => changes[t.key]);
+      if (changed) renderButtons();
+    }
+  });
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/mealListView.js
+++ b/mealListView.js
@@ -211,6 +211,9 @@ async function init() {
     if (area === 'local' && changes.users) {
       location.reload();
     }
+    if (area === 'local' && changes[key]) {
+      location.reload();
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- make meal list selector rerender on storage change
- reload meal list views if their meal type changes
- refresh meal chooser when any meal list updates

## Testing
- `node --check mealListSelect.js`
- `node --check mealListView.js`
- `node --check mealChooser.js`


------
https://chatgpt.com/codex/tasks/task_e_686037fe8e0c8329853b7f9a23051737