### PR TITLE
Add custom meal categories

### DIFF
--- a/addMeal.js
+++ b/addMeal.js
@@ -1,11 +1,10 @@
 import { loadJSON } from './utils/dataLoader.js';
-import { MEAL_TYPES } from './utils/mealData.js';
+import { MEAL_TYPES, initializeMealCategories } from './utils/mealData.js';
 import { calculateAndSaveMealNeeds } from './utils/mealNeedsCalculator.js';
 
 const params = new URLSearchParams(location.search);
 const mealType = params.get('type') || 'lunchDinner';
-const { key: MEAL_KEY, path: MEAL_PATH, label } =
-  MEAL_TYPES[mealType] || MEAL_TYPES.lunchDinner;
+let MEAL_KEY, MEAL_PATH, label;
 const UOM_PATH = 'Required for grocery app/uom_conversion_table.json';
 
 function loadMeals() {
@@ -81,6 +80,11 @@ function anyFilled(row) {
 }
 
 async function init() {
+  await initializeMealCategories();
+  const info = MEAL_TYPES[mealType] || MEAL_TYPES.lunchDinner;
+  MEAL_KEY = info.key;
+  MEAL_PATH = info.path;
+  label = info.label;
   const titleEl = document.getElementById('title');
   if (titleEl) titleEl.textContent = `Add ${label} Meal`;
   const units = await loadUnits();

--- a/mealChooser.html
+++ b/mealChooser.html
@@ -13,12 +13,7 @@
   <h1>Meal Chooser</h1>
   <div id="userButtons"></div>
   <label>Category:
-    <select id="categorySelect">
-      <option value="breakfast">Breakfast</option>
-      <option value="lunchDinner">Lunch/Dinner</option>
-      <option value="snack">Snack</option>
-      <option value="dessert">Dessert</option>
-    </select>
+    <select id="categorySelect"></select>
   </label>
   <div id="remaining"></div>
   <button id="resetBtn">Reset</button>

--- a/mealChooser.js
+++ b/mealChooser.js
@@ -1,5 +1,5 @@
 import { loadUsers } from './utils/userData.js';
-import { MEAL_TYPES, DEFAULT_MEALS_PER_DAY, loadMealsPerDay } from './utils/mealData.js';
+import { MEAL_TYPES, DEFAULT_MEALS_PER_DAY, loadMealsPerDay, initializeMealCategories } from './utils/mealData.js';
 import { loadJSON } from './utils/dataLoader.js';
 
 function getCurrentWeek() {
@@ -59,8 +59,16 @@ function usesMeal(meal, idx, userNames) {
 }
 
 async function init() {
+  await initializeMealCategories();
   const userButtons = document.getElementById('userButtons');
   const categorySelect = document.getElementById('categorySelect');
+  categorySelect.innerHTML = '';
+  Object.keys(MEAL_TYPES).forEach(key => {
+    const opt = document.createElement('option');
+    opt.value = key;
+    opt.textContent = MEAL_TYPES[key].label;
+    categorySelect.appendChild(opt);
+  });
   const mealButtons = document.getElementById('mealButtons');
   const remainingDiv = document.getElementById('remaining');
   const resetBtn = document.getElementById('resetBtn');

--- a/mealListSelect.html
+++ b/mealListSelect.html
@@ -11,6 +11,7 @@
 <body>
   <h1>Select Meal List</h1>
   <div id="listButtons"></div>
+  <button id="newCategoryBtn">New Category</button>
   <script type="module" src="mealListSelect.js"></script>
 </body>
 </html>

--- a/mealListSelect.js
+++ b/mealListSelect.js
@@ -1,4 +1,4 @@
-import { MEAL_TYPES } from './utils/mealData.js';
+import { MEAL_TYPES, initializeMealCategories, addMealCategory } from './utils/mealData.js';
 import { loadJSON } from './utils/dataLoader.js';
 import { openOrFocusWindow } from './utils/windowUtils.js';
 
@@ -31,8 +31,37 @@ async function renderButtons() {
   }
 }
 
+function startAddCategory() {
+  const div = document.getElementById('listButtons');
+  if (div.querySelector('input.newCat')) return;
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'newCat';
+  input.placeholder = 'Category name';
+  const saveBtn = document.createElement('button');
+  saveBtn.textContent = 'Save';
+  saveBtn.style.display = 'none';
+  input.addEventListener('input', () => {
+    saveBtn.style.display = input.value.trim() ? '' : 'none';
+  });
+  saveBtn.addEventListener('click', async () => {
+    const val = input.value.trim();
+    if (!val) return;
+    await addMealCategory(val);
+    input.remove();
+    saveBtn.remove();
+    renderButtons();
+  });
+  div.appendChild(input);
+  div.appendChild(saveBtn);
+  input.focus();
+}
+
 async function init() {
+  await initializeMealCategories();
   await renderButtons();
+  const newBtn = document.getElementById('newCategoryBtn');
+  if (newBtn) newBtn.addEventListener('click', startAddCategory);
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'local') {
       const changed = Object.values(MEAL_TYPES).some(t => changes[t.key]);

--- a/mealListView.js
+++ b/mealListView.js
@@ -1,4 +1,4 @@
-import { MEAL_TYPES } from './utils/mealData.js';
+import { MEAL_TYPES, initializeMealCategories } from './utils/mealData.js';
 import { loadJSON } from './utils/dataLoader.js';
 import { calculateAndSaveMealNeeds } from './utils/mealNeedsCalculator.js';
 import { openOrFocusWindow } from './utils/windowUtils.js';
@@ -8,8 +8,8 @@ import { canonicalName } from './utils/nameUtils.js';
 const STOCK_PATH = 'Required for grocery app/current_stock_table.json';
 
 const params = new URLSearchParams(location.search);
-const type = params.get('type') || 'breakfast';
-const { key, path, label } = MEAL_TYPES[type] || MEAL_TYPES.breakfast;
+let type = params.get('type') || 'breakfast';
+let key, path, label;
 
 let inventorySet = new Set();
 const ingredientCells = {};
@@ -284,6 +284,11 @@ function updateInventoryDisplay() {
 }
 
 async function init() {
+  await initializeMealCategories();
+  const info = MEAL_TYPES[type] || MEAL_TYPES.breakfast;
+  key = info.key;
+  path = info.path;
+  label = info.label;
   document.getElementById('title').textContent = `${label} Meals`;
   const addBtn = document.getElementById('addMeal');
   if (addBtn) {

--- a/mealMultiplier.js
+++ b/mealMultiplier.js
@@ -1,4 +1,4 @@
-import { MEAL_TYPES, DEFAULT_MEALS_PER_DAY, loadMealsPerDay, saveMealsPerDay } from './utils/mealData.js';
+import { MEAL_TYPES, DEFAULT_MEALS_PER_DAY, loadMealsPerDay, saveMealsPerDay, initializeMealCategories } from './utils/mealData.js';
 
 let data = {};
 
@@ -44,6 +44,7 @@ function buildRow(key, label, tbody) {
 }
 
 async function init() {
+  await initializeMealCategories();
   data = await loadMealsPerDay();
   const tbody = document.getElementById('multiplierBody');
   Object.keys(MEAL_TYPES).forEach(key => {

--- a/users.js
+++ b/users.js
@@ -1,5 +1,5 @@
 import { loadUsers, saveUsers } from './utils/userData.js';
-import { MEAL_TYPES } from './utils/mealData.js';
+import { MEAL_TYPES, initializeMealCategories } from './utils/mealData.js';
 import { loadJSON } from './utils/dataLoader.js';
 
 const btnContainer = document.getElementById('userButtons');
@@ -136,6 +136,7 @@ async function showMeals(userIndex) {
 }
 
 async function init() {
+  await initializeMealCategories();
   users = await loadUsers();
   renderButtons();
   editBtn.addEventListener('click', () => {

--- a/utils/mealData.js
+++ b/utils/mealData.js
@@ -21,6 +21,44 @@ export const MEAL_TYPES = {
   }
 };
 
+export async function initializeMealCategories() {
+  return new Promise(resolve => {
+    chrome.storage.local.get('mealCategories', data => {
+      const cats = data.mealCategories || [];
+      cats.forEach(cat => {
+        MEAL_TYPES[cat.id] = cat;
+      });
+      resolve();
+    });
+  });
+}
+
+export async function addMealCategory(label) {
+  const id = (label || '').trim().toLowerCase().replace(/\s+/g, '');
+  if (!id) return null;
+  const key = `${id}Meals`;
+  const cat = { id, key, path: '', label };
+  const cats = await new Promise(resolve => {
+    chrome.storage.local.get('mealCategories', d => resolve(d.mealCategories || []));
+  });
+  if (!cats.find(c => c.id === id)) {
+    cats.push(cat);
+    await new Promise(res => chrome.storage.local.set({ mealCategories: cats }, () => res()));
+  }
+  MEAL_TYPES[id] = cat;
+  const mealsPerDay = await loadMealsPerDay();
+  if (mealsPerDay[id] === undefined) {
+    mealsPerDay[id] = 1;
+    await saveMealsPerDay(mealsPerDay);
+  }
+  await new Promise(res => chrome.storage.local.get(key, data => {
+    if (!data[key]) {
+      chrome.storage.local.set({ [key]: [] }, () => res());
+    } else res();
+  }));
+  return cat;
+}
+
 // Default daily meal counts used by mealMath.js
 export const DEFAULT_MEALS_PER_DAY = {
   breakfast: 1,

--- a/utils/mealNeedsCalculator.js
+++ b/utils/mealNeedsCalculator.js
@@ -1,4 +1,4 @@
-import { MEAL_TYPES, DEFAULT_MEALS_PER_DAY, loadMealsPerDay } from './mealData.js';
+import { MEAL_TYPES, DEFAULT_MEALS_PER_DAY, loadMealsPerDay, initializeMealCategories } from './mealData.js';
 import { loadJSON } from './dataLoader.js';
 import { calculateMonthlyMealSpots } from './mealMath.js';
 
@@ -29,6 +29,7 @@ function loadMeals(type) {
 }
 
 export async function calculateAndSaveMealNeeds() {
+  await initializeMealCategories();
   const monthlyMap = {};
   const mealsPerDay = await loadMealsPerDay();
   for (const type of Object.keys(MEAL_TYPES)) {


### PR DESCRIPTION
## Summary
- allow defining new meal categories via `New Category` button
- persist custom categories in storage and add helpers
- load meal categories dynamically across UI and meal math
- update meal chooser to populate category list dynamically

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68615cba14d88329b25ba536fbba457a