### PR TITLE
Fix duplicate buttons after adding category

### DIFF
--- a/mealListSelect.js
+++ b/mealListSelect.js
@@ -50,7 +50,6 @@ function startAddCategory() {
     await addMealCategory(val);
     input.remove();
     saveBtn.remove();
-    renderButtons();
   });
   div.appendChild(input);
   div.appendChild(saveBtn);


### PR DESCRIPTION
## Summary
- avoid calling `renderButtons` twice when saving a new category

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68615fbfe7f08329878ba173a0e2abba