### PR TITLE
Set week default to current week

### DIFF
--- a/inventory.js
+++ b/inventory.js
@@ -153,8 +153,16 @@ function renderWeek(week) {
   }, headerState);
 }
 
+function getCurrentWeek() {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), 0, 1);
+  const dayOfYear = Math.floor((now - start) / 86400000) + 1;
+  return Math.ceil((dayOfYear + start.getDay()) / 7);
+}
+
 async function init() {
   const weekInput = document.getElementById('week-number');
+  weekInput.value = getCurrentWeek();
   [baseStock, purchasesMap, consumptionData, mealMonthData, expirationData, needsData] = await Promise.all([
     loadStock(),
     loadPurchases(),


### PR DESCRIPTION
## Summary
- compute the current week number
- default the inventory editing week to the current week on load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686181b2df748329a90d01637f8f8751