### PR TITLE
Fix item name matching when spaces differ

### DIFF
--- a/utils/nameUtils.js
+++ b/utils/nameUtils.js
@@ -1,3 +1,6 @@
 export function canonicalName(name) {
-  return (name || '').trim().toLowerCase();
+  return (name || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
 }


### PR DESCRIPTION
## Summary
- normalize whitespace in `canonicalName` so meal ingredient names match inventory

## Testing
- `node - <<'EOF'
const {canonicalName}=require('./utils/nameUtils.js');
console.log(canonicalName('Birds Eye Skillet Meals  Frozen Foods'));
console.log(canonicalName('Birds Eye Skillet Meals Frozen Foods'));
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6862869577248329bf24e2254b7ab46b