### PR TITLE
Improve realtime updates without page reloads

### DIFF
--- a/mealChooser.js
+++ b/mealChooser.js
@@ -73,7 +73,7 @@ async function init() {
   const remainingDiv = document.getElementById('remaining');
   const resetBtn = document.getElementById('resetBtn');
 
-  const users = await loadUsers();
+  let users = await loadUsers();
   let slots = await loadMealSlots();
   const mealsPerDay = await loadMealsPerDay();
   let currentUser = 0;
@@ -100,6 +100,7 @@ async function init() {
   }
 
   async function renderMeals() {
+    const scrollTop = window.scrollY;
     const type = categorySelect.value;
     const meals = await loadMeals(type);
     mealButtons.innerHTML = '';
@@ -136,6 +137,7 @@ async function init() {
         mealButtons.appendChild(btn);
       }
     });
+    window.scrollTo(0, scrollTop);
   }
 
   renderUserButtons();
@@ -153,7 +155,13 @@ async function init() {
         renderMeals();
       }
       if (changes.users) {
-        location.reload();
+        Promise.all([loadUsers(), loadMealSlots()]).then(([u, s]) => {
+          users = u;
+          slots = s;
+          currentUser = Math.min(currentUser, users.length - 1);
+          renderUserButtons();
+          renderMeals();
+        });
       }
     }
   });

--- a/mealListView.js
+++ b/mealListView.js
@@ -115,7 +115,7 @@ function createRows(meal, arr) {
         if (idx !== -1) arr.splice(idx, 1);
         await saveMeals(arr);
         await calculateAndSaveMealNeeds();
-        location.reload();
+        loadAndRender();
       });
 
       nameTd.appendChild(document.createElement('br'));
@@ -189,7 +189,7 @@ function createRows(meal, arr) {
       if (idx !== -1) arr.splice(idx, 1);
       await saveMeals(arr);
       await calculateAndSaveMealNeeds();
-      location.reload();
+      loadAndRender();
     });
     nameTd.appendChild(document.createElement('br'));
     nameTd.appendChild(editBtn);
@@ -277,7 +277,7 @@ function createRows(meal, arr) {
         await calculateAndSaveMealNeeds();
       }
       hideEdit();
-      if (changed) location.reload();
+      if (changed) loadAndRender();
     }
 
     function hideEdit() {
@@ -312,6 +312,28 @@ function updateInventoryDisplay() {
   });
 }
 
+async function loadAndRender() {
+  const scrollTop = window.scrollY;
+  const tbody = document.getElementById('mealBody');
+  tbody.innerHTML = '';
+  deleteButtons.length = 0;
+  Object.keys(ingredientCells).forEach(k => delete ingredientCells[k]);
+  const [meals, stock, users] = await Promise.all([
+    loadMeals(),
+    loadStock(),
+    loadUsers()
+  ]);
+  userNames = users;
+  inventorySet = new Set(stock.map(s => canonicalName(s.name)));
+  meals.forEach(meal => {
+    const rows = createRows(meal, meals);
+    rows.forEach(row => tbody.appendChild(row));
+  });
+  updateInventoryDisplay();
+  await calculateAndSaveMealNeeds();
+  window.scrollTo(0, scrollTop);
+}
+
 async function init() {
   await initializeMealCategories();
   const info = MEAL_TYPES[type] || MEAL_TYPES.breakfast;
@@ -335,20 +357,7 @@ async function init() {
       });
     });
   }
-  const tbody = document.getElementById('mealBody');
-  const [meals, stock, users] = await Promise.all([
-    loadMeals(),
-    loadStock(),
-    loadUsers()
-  ]);
-  userNames = users;
-  inventorySet = new Set(stock.map(s => canonicalName(s.name)));
-  meals.forEach(meal => {
-    const rows = createRows(meal, meals);
-    rows.forEach(row => tbody.appendChild(row));
-  });
-  updateInventoryDisplay();
-  await calculateAndSaveMealNeeds();
+  await loadAndRender();
 
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'local' && changes.currentStock) {
@@ -357,10 +366,10 @@ async function init() {
       updateInventoryDisplay();
     }
     if (area === 'local' && changes.users) {
-      location.reload();
+      loadAndRender();
     }
     if (area === 'local' && changes[key]) {
-      location.reload();
+      loadAndRender();
     }
   });
 }

--- a/popup.js
+++ b/popup.js
@@ -246,6 +246,78 @@ async function refreshNeeds(stock = stockData, consumed = consumedYearData) {
   });
 }
 
+async function rerenderAll() {
+  const scrollTop = window.scrollY;
+  const {
+    needs,
+    selections,
+    consumption,
+    stock,
+    expiration,
+    consumed,
+    purchases,
+    mealYear
+  } = await getData();
+  needsData = needs;
+  const sortedNeeds = sortItemsByCategory(needs);
+  consumptionData = consumption;
+  consumptionMap = new Map(consumption.map(c => [c.name, c]));
+  expirationData = expiration;
+  stockData = stock;
+  consumedYearData = consumed;
+  mealYearData = mealYear;
+  purchasesData = purchases;
+  const week = getCurrentWeek();
+  const purchaseInfo = calculatePurchaseNeeds(
+    needs,
+    consumption,
+    stock,
+    expiration,
+    consumed,
+    mealYear,
+    purchases,
+    week
+  );
+  const purchaseMap = new Map(purchaseInfo.map(p => [p.name, p]));
+  const stockMap = new Map(stock.map(i => [i.name, i]));
+  const itemsContainer = document.getElementById('items');
+  itemsContainer.innerHTML = '';
+  finalMap.clear();
+  renderItemsWithCategoryHeaders(sortedNeeds, itemsContainer, item => {
+    const li = document.createElement('li');
+    const info = purchaseMap.get(item.name);
+    const needAmt = info ? Math.round(info.toBuy) : null;
+    const amountText =
+      info && !isNaN(needAmt) ? ` (Need: ${needAmt} ${info.home_unit})` : '';
+    const btn = document.createElement('button');
+    btn.textContent = item.name + amountText;
+    btn.addEventListener('click', () => {
+      openOrFocusWindow(`item.html?item=${encodeURIComponent(item.name)}`);
+    });
+    li.appendChild(btn);
+    const finalSpan = document.createElement('span');
+    const finalImg = document.createElement('img');
+    finalImg.className = 'final-product-img';
+    finalImg.width = 50;
+    finalImg.height = 50;
+    finalImg.style.display = 'none';
+    const currentQty = stockMap.get(item.name)?.amount || 0;
+    const weeklyNeed = item.total_needed_year ? item.total_needed_year / 52 : 0;
+    const showByStock = currentQty < weeklyNeed;
+    const showByNeed = !hideZeroItems || (needAmt != null && needAmt > 0);
+    li.style.display = showByStock && showByNeed ? 'list-item' : 'none';
+    getFinal(item.name).then(async store => {
+      const product = await getFinalProduct(item.name);
+      updateFinalInfo(item.name, finalSpan, finalImg, store, product);
+    });
+    li.appendChild(finalSpan);
+    li.appendChild(finalImg);
+    finalMap.set(item.name, { li, btn, span: finalSpan, img: finalImg });
+    return li;
+  }, headerState);
+  window.scrollTo(0, scrollTop);
+}
+
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area === 'local' && changes.currentStock) {
     const newStock = changes.currentStock.newValue || [];
@@ -276,7 +348,7 @@ chrome.storage.onChanged.addListener((changes, area) => {
     area === 'local' &&
     (changes.yearlyNeeds || changes.monthlyConsumption || changes.expirationData)
   ) {
-    location.reload();
+    rerenderAll();
   }
 });
 


### PR DESCRIPTION
## Summary
- avoid page refreshes by rerendering popup when data changes
- reload meal chooser and meal list view dynamically when storage updates
- keep scroll position when rerendering lists

## Testing
- `node --check popup.js`
- `node --check mealChooser.js`
- `node --check mealListView.js`


------
https://chatgpt.com/codex/tasks/task_e_6863f1ea843483299a557fd0b716719b