### PR TITLE
Implement per-user meal days

### DIFF
--- a/users.html
+++ b/users.html
@@ -12,6 +12,8 @@
       margin-top: 10px;
       cursor: pointer;
     }
+    .hidden { display: none; }
+    input[type="number"] { width: 60px; }
   </style>
 </head>
 <body>

--- a/users.js
+++ b/users.js
@@ -1,10 +1,12 @@
-import { loadUsers, saveUsers } from './utils/userData.js';
+import {
+  loadUsers,
+  saveUsers,
+  loadUserCategoryDays,
+  saveUserCategoryDays
+} from './utils/userData.js';
 import { MEAL_TYPES, initializeMealCategories } from './utils/mealData.js';
 import { loadJSON } from './utils/dataLoader.js';
-import {
-  sortItemsByCategory,
-  renderItemsWithCategoryHeaders
-} from './utils/sortByCategory.js';
+import { sortItemsByCategory } from './utils/sortByCategory.js';
 
 const btnContainer = document.getElementById('userButtons');
 const mealList = document.getElementById('mealList');
@@ -12,6 +14,7 @@ const editBtn = document.getElementById('editNamesBtn');
 const saveNamesBtn = document.getElementById('saveNamesBtn');
 
 let users = [];
+let userDays = [];
 let addInput = null;
 let saveBtn = null;
 let addBtn = null;
@@ -57,7 +60,8 @@ async function saveNewUser() {
   const val = addInput.value.trim();
   if (!val) return;
   users.push(val);
-  await saveUsers(users);
+  userDays.push({});
+  await Promise.all([saveUsers(users), saveUserCategoryDays(userDays)]);
   addInput.remove();
   saveBtn.remove();
   addInput = null;
@@ -136,21 +140,90 @@ async function showMeals(userIndex) {
   });
   const sorted = sortItemsByCategory(usedMeals);
   mealList.innerHTML = '';
-  renderItemsWithCategoryHeaders(
-    sorted,
-    mealList,
-    m => {
-      const li = document.createElement('li');
-      li.textContent = m.name || '';
-      return li;
-    },
-    headerState
-  );
+
+  let lastCat = null;
+  let header = null;
+  let nodes = [];
+
+  function finalizeHeader(cat, hdr, ns) {
+    if (!hdr) return;
+    const hidden = headerState[cat] !== undefined ? headerState[cat] : true;
+    hdr.dataset.hidden = hidden ? 'true' : 'false';
+    ns.forEach(n => {
+      n.style.display = hidden ? 'none' : '';
+    });
+    hdr.style.cursor = 'pointer';
+    hdr.addEventListener('click', () => {
+      const isHidden = hdr.dataset.hidden === 'true';
+      hdr.dataset.hidden = isHidden ? 'false' : 'true';
+      ns.forEach(n => {
+        n.style.display = isHidden ? '' : 'none';
+      });
+      headerState[cat] = !isHidden;
+    });
+  }
+
+  const daysRec = userDays[userIndex] || {};
+
+  sorted.forEach(m => {
+    const cat = m.category || 'Other';
+    if (cat !== lastCat) {
+      finalizeHeader(lastCat, header, nodes);
+      lastCat = cat;
+      header = document.createElement('h3');
+      header.className = 'category-header';
+      header.textContent = cat;
+      mealList.appendChild(header);
+
+      const div = document.createElement('div');
+      const label = document.createElement('span');
+      label.textContent = 'Days per week: ';
+      const input = document.createElement('input');
+      input.type = 'number';
+      input.min = '0';
+      input.max = '7';
+      input.step = 'any';
+      input.value = daysRec[cat] ?? 1;
+      const save = document.createElement('button');
+      save.textContent = 'Save';
+      save.className = 'hidden';
+      function update() {
+        const cur = daysRec[cat] ?? 1;
+        if (input.value.trim() && parseFloat(input.value) !== parseFloat(cur)) {
+          save.classList.remove('hidden');
+        } else {
+          save.classList.add('hidden');
+        }
+      }
+      input.addEventListener('input', update);
+      save.addEventListener('click', async () => {
+        const val = parseFloat(input.value);
+        if (isNaN(val)) return;
+        if (!userDays[userIndex]) userDays[userIndex] = {};
+        userDays[userIndex][cat] = val;
+        await saveUserCategoryDays(userDays);
+        save.classList.add('hidden');
+        try { chrome.runtime.sendMessage({ type: 'inventory-updated' }); } catch (_) {}
+      });
+      div.appendChild(label);
+      div.appendChild(input);
+      div.appendChild(save);
+      mealList.appendChild(div);
+      nodes = [div];
+    }
+    const li = document.createElement('li');
+    li.textContent = m.name || '';
+    mealList.appendChild(li);
+    nodes.push(li);
+  });
+  finalizeHeader(lastCat, header, nodes);
 }
 
 async function init() {
   await initializeMealCategories();
   users = await loadUsers();
+  userDays = await loadUserCategoryDays();
+  while (userDays.length < users.length) userDays.push({});
   renderButtons();
   editBtn.addEventListener('click', () => {
     if (editing) return;

--- a/utils/mealNeedsCalculator.js
+++ b/utils/mealNeedsCalculator.js
@@ -1,6 +1,11 @@
-import { MEAL_TYPES, DEFAULT_MEALS_PER_DAY, loadMealsPerDay, initializeMealCategories } from './mealData.js';
+import {
+  MEAL_TYPES,
+  DEFAULT_MEALS_PER_DAY,
+  loadMealsPerDay,
+  initializeMealCategories
+} from './mealData.js';
 import { loadJSON } from './dataLoader.js';
-import { calculateMonthlyMealSpots } from './mealMath.js';
+import { loadUsers, loadUserCategoryDays } from './userData.js';
 
 function parseAmount(str) {
   if (!str) return 0;
@@ -32,24 +37,40 @@ export async function calculateAndSaveMealNeeds() {
   await initializeMealCategories();
   const monthlyMap = {};
   const mealsPerDay = await loadMealsPerDay();
+  const users = await loadUsers();
+  const userDays = await loadUserCategoryDays();
+
+  while (userDays.length < users.length) userDays.push({});
+
   for (const type of Object.keys(MEAL_TYPES)) {
     const meals = await loadMeals(type);
-    const active = meals.filter(m => (m.people ?? m.multiplier ?? 1) > 0);
+    const active = meals.filter(m => {
+      if (Array.isArray(m.users)) return m.users.some(Boolean);
+      return (m.people ?? m.multiplier ?? 1) > 0;
+    });
     if (!active.length) continue;
     const totalCount = active.length;
-    const baseSpots = calculateMonthlyMealSpots(
-      mealsPerDay[type] ?? DEFAULT_MEALS_PER_DAY[type],
-      1,
-      7,
-      totalCount
-    );
+    const perDay = mealsPerDay[type] ?? DEFAULT_MEALS_PER_DAY[type];
+
     active.forEach(meal => {
-      const people = meal.people ?? meal.multiplier ?? 1;
-      const mealSpots = baseSpots * people;
+      let personDays = 0;
+      if (Array.isArray(meal.users)) {
+        meal.users.forEach((use, idx) => {
+          if (use) {
+            const days = userDays[idx]?.[type];
+            personDays += days === undefined ? 1 : parseFloat(days);
+          }
+        });
+      } else {
+        const people = meal.people ?? meal.multiplier ?? 1;
+        personDays = people * 1;
+      }
+      if (personDays <= 0) return;
+      const monthlySpots = (perDay * personDays * 52) / totalCount / 12;
       (meal.ingredients || []).forEach(ing => {
         const serving = parseAmount(ing.serving_size || ing.amount);
         if (!serving) return;
-        const need = serving * mealSpots;
+        const need = serving * monthlySpots;
         monthlyMap[ing.name] = (monthlyMap[ing.name] || 0) + need;
       });
     });

--- a/utils/userData.js
+++ b/utils/userData.js
@@ -16,3 +16,21 @@ export function saveUsers(arr) {
     chrome.storage.local.set({ users: arr }, () => resolve());
   });
 }
+
+export function loadUserCategoryDays() {
+  return new Promise(resolve => {
+    chrome.storage.local.get('userCategoryDays', data => {
+      if (Array.isArray(data.userCategoryDays)) {
+        resolve(data.userCategoryDays);
+      } else {
+        resolve([]);
+      }
+    });
+  });
+}
+
+export function saveUserCategoryDays(arr) {
+  return new Promise(resolve => {
+    chrome.storage.local.set({ userCategoryDays: arr }, () => resolve());
+  });
+}


### PR DESCRIPTION
## Summary
- allow storing user-specific days per meal category
- use the per-user days when calculating monthly meal needs
- show editable days inputs on the user meals page

## Testing
- `node --check utils/userData.js`
- `node --check utils/mealNeedsCalculator.js`
- `node --check users.js`


------
https://chatgpt.com/codex/tasks/task_e_68640954c2588329b14544a1ccaa5afa