### PR TITLE
Fix meal plan updates

### DIFF
--- a/mealMultiplier.js
+++ b/mealMultiplier.js
@@ -1,4 +1,11 @@
-import { MEAL_TYPES, DEFAULT_MEALS_PER_DAY, loadMealsPerDay, saveMealsPerDay, initializeMealCategories } from './utils/mealData.js';
+import {
+  MEAL_TYPES,
+  DEFAULT_MEALS_PER_DAY,
+  loadMealsPerDay,
+  saveMealsPerDay,
+  initializeMealCategories
+} from './utils/mealData.js';
+import { calculateAndSaveMealNeeds } from './utils/mealNeedsCalculator.js';
 
 let data = {};
 
@@ -30,10 +37,13 @@ function buildRow(key, label, tbody) {
     if (isNaN(val)) return;
     data[key] = val;
     await saveMealsPerDay(data);
+    await calculateAndSaveMealNeeds();
     curTd.textContent = val;
     input.value = '';
     saveBtn.classList.add('hidden');
-    try { chrome.runtime.sendMessage({ type: 'inventory-updated' }); } catch (_) {}
+    try {
+      chrome.runtime.sendMessage({ type: 'inventory-updated' });
+    } catch (_) {}
   });
 
   tr.appendChild(catTd);

--- a/users.js
+++ b/users.js
@@ -5,6 +5,7 @@ import {
   saveUserCategoryDays
 } from './utils/userData.js';
 import { MEAL_TYPES, initializeMealCategories } from './utils/mealData.js';
+import { calculateAndSaveMealNeeds } from './utils/mealNeedsCalculator.js';
 import { loadJSON } from './utils/dataLoader.js';
 import { sortItemsByCategory } from './utils/sortByCategory.js';
 
@@ -202,8 +203,11 @@ async function showMeals(userIndex) {
         if (!userDays[userIndex]) userDays[userIndex] = {};
         userDays[userIndex][cat] = val;
         await saveUserCategoryDays(userDays);
+        await calculateAndSaveMealNeeds();
         save.classList.add('hidden');
-        try { chrome.runtime.sendMessage({ type: 'inventory-updated' }); } catch (_) {}
+        try {
+          chrome.runtime.sendMessage({ type: 'inventory-updated' });
+        } catch (_) {}
       });
       div.appendChild(label);
       div.appendChild(input);


### PR DESCRIPTION
## Summary
- ensure the meal plan recalculates when meal multipliers or user day counts change
- update both **mealMultiplier.js** and **users.js** to call `calculateAndSaveMealNeeds`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68640d04e9b48329bff4d8a153c63af9