### PR TITLE
Add detailed meal plan breakdown for weekly need debug

### DIFF
--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -78,6 +78,12 @@ function loadStoredArray(key) {
   });
 }
 
+function loadStoredObj(key) {
+  return new Promise(resolve => {
+    chrome.storage.local.get(key, data => resolve(data[key] || {}));
+  });
+}
+
 function getCurrentWeek() {
   const start = new Date(new Date().getFullYear(), 0, 1);
   const today = new Date();
@@ -85,18 +91,19 @@ function getCurrentWeek() {
 }
 
 async function loadData() {
-  const [needs, expiration, stock, consumption, mealYear, mealMonth] = await Promise.all([
+  const [needs, expiration, stock, consumption, mealYear, mealMonth, mealBreakdown] = await Promise.all([
     loadArray('yearlyNeeds', 'Required for grocery app/yearly_needs_with_manual_flags.json'),
     loadArray('expirationData', 'Required for grocery app/expiration_times_full.json'),
     loadArray('currentStock', 'Required for grocery app/current_stock_table.json'),
     loadArray('monthlyConsumption', 'Required for grocery app/monthly_consumption_table.json'),
     loadStoredArray('mealPlanYearly'),
-    loadStoredArray('mealPlanMonthly')
+    loadStoredArray('mealPlanMonthly'),
+    loadStoredObj('mealPlanMonthlyBreakdown')
   ]);
-  return { needs, expiration, stock, consumption, mealYear, mealMonth };
+  return { needs, expiration, stock, consumption, mealYear, mealMonth, mealBreakdown };
 }
 
-function buildItemMap(needs, expiration, stock, consumption, mealMonth) {
+function buildItemMap(needs, expiration, stock, consumption, mealMonth, mealBreakdown = {}) {
   const expMap = {};
   expiration.forEach(e => {
     expMap[canonicalName(e.name)] = e.shelf_life_months * WEEKS_PER_MONTH;
@@ -128,12 +135,14 @@ function buildItemMap(needs, expiration, stock, consumption, mealMonth) {
     const base = baseMap[key] || 0;
     const meal = mealMap[key] || 0;
     const total = consMap[key] || 0;
+    const breakdown = mealBreakdown[key] || {};
     return {
       name: n.name,
       category: n.category || '',
       units_per_purchase: 1,
       base_monthly_consumption: base,
       meal_monthly_consumption: meal,
+      meal_breakdown: breakdown,
       weekly_consumption: total / WEEKS_PER_MONTH,
       expiration_weeks: expMap[key] || 52,
       starting_stock: stockMap[key] || 0,
@@ -363,7 +372,8 @@ async function fetchItems() {
     data.expiration,
     data.stock,
     data.consumption,
-    data.mealMonth
+    data.mealMonth,
+    data.mealBreakdown
   );
   const [savedMap, overridesMap] = await Promise.all([
     loadPurchases(),

--- a/utils/mealNeedsCalculator.js
+++ b/utils/mealNeedsCalculator.js
@@ -36,6 +36,7 @@ function loadMeals(type) {
 export async function calculateAndSaveMealNeeds() {
   await initializeMealCategories();
   const monthlyMap = {};
+  const monthlyBreakdown = {};
   const mealsPerDay = await loadMealsPerDay();
   const users = await loadUsers();
   const userDays = await loadUserCategoryDays();
@@ -71,6 +72,9 @@ export async function calculateAndSaveMealNeeds() {
           if (!serving) return;
           const need = serving * monthlySpots;
           monthlyMap[ing.name] = (monthlyMap[ing.name] || 0) + need;
+          if (!monthlyBreakdown[ing.name]) monthlyBreakdown[ing.name] = {};
+          monthlyBreakdown[ing.name][meal.name] =
+            (monthlyBreakdown[ing.name][meal.name] || 0) + need;
         });
       } else {
         const people = meal.people ?? meal.multiplier ?? 1;
@@ -92,6 +96,9 @@ export async function calculateAndSaveMealNeeds() {
           if (!serving) return;
           const need = serving * monthlySpots;
           monthlyMap[ing.name] = (monthlyMap[ing.name] || 0) + need;
+          if (!monthlyBreakdown[ing.name]) monthlyBreakdown[ing.name] = {};
+          monthlyBreakdown[ing.name][meal.name] =
+            (monthlyBreakdown[ing.name][meal.name] || 0) + need;
         });
       }
     });
@@ -110,20 +117,28 @@ export async function calculateAndSaveMealNeeds() {
   }));
   await new Promise(resolve => {
     chrome.storage.local.set(
-      { mealPlanMonthly: monthlyArr, mealPlanYearly: yearlyArr },
+      {
+        mealPlanMonthly: monthlyArr,
+        mealPlanYearly: yearlyArr,
+        mealPlanMonthlyBreakdown: monthlyBreakdown
+      },
       () => resolve()
     );
   });
-  return { monthlyArr, yearlyArr };
+  return { monthlyArr, yearlyArr, monthlyBreakdown };
 }
 
 export function loadMealPlanData() {
   return new Promise(resolve => {
-    chrome.storage.local.get(['mealPlanMonthly', 'mealPlanYearly'], data => {
-      resolve({
-        monthly: data.mealPlanMonthly || [],
-        yearly: data.mealPlanYearly || []
-      });
-    });
+    chrome.storage.local.get(
+      ['mealPlanMonthly', 'mealPlanYearly', 'mealPlanMonthlyBreakdown'],
+      data => {
+        resolve({
+          monthly: data.mealPlanMonthly || [],
+          yearly: data.mealPlanYearly || [],
+          breakdown: data.mealPlanMonthlyBreakdown || {}
+        });
+      }
+    );
   });
 }

--- a/weeklyNeedDebug.js
+++ b/weeklyNeedDebug.js
@@ -1,17 +1,40 @@
-document.addEventListener('DOMContentLoaded', () => {
+function canonicalName(name) {
+  return (name || '').trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function loadBreakdown(key) {
+  return new Promise(resolve => {
+    try {
+      chrome.storage.local.get('mealPlanMonthlyBreakdown', data => {
+        resolve((data.mealPlanMonthlyBreakdown || {})[key] || {});
+      });
+    } catch (e) {
+      resolve({});
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
   const params = new URLSearchParams(location.search);
   const item = params.get('item') || '';
+  const key = canonicalName(item);
   const base = parseFloat(params.get('base') || '0');
   const meal = parseFloat(params.get('meal') || '0');
   const wpm = parseFloat(params.get('wpm') || '4.33');
-  const weekly = parseFloat(params.get('weekly') || ((base + meal) / wpm));
+  const weekly = parseFloat(params.get('weekly') || (base + meal) / wpm);
+  const breakdown = await loadBreakdown(key);
   const lines = [
     `${base.toFixed(2)} (base monthly consumption)`,
-    `${meal.toFixed(2)} (meal plan monthly consumption)`,
+    `${meal.toFixed(2)} (meal plan monthly consumption)`
+  ];
+  Object.keys(breakdown).forEach(m => {
+    lines.push(`  - ${m}: ${breakdown[m].toFixed(2)}`);
+  });
+  lines.push(
     `${(base + meal).toFixed(2)} (combined monthly consumption)`,
     `${wpm.toFixed(2)} (weeks per month)`,
     `${weekly.toFixed(2)} (weekly need)`
-  ];
+  );
   document.getElementById('item').textContent = item;
   document.getElementById('info').textContent = lines.join('\n');
 });


### PR DESCRIPTION
## Summary
- store per-meal breakdown when calculating meal plan needs
- expose meal plan breakdown via `loadMealPlanData`
- load stored meal-plan breakdown in the inventory timeline
- include meal-plan breakdown in items returned by `buildItemMap`
- update the debug popup to show per-meal contributions

## Testing
- `node -e "require('./weeklyNeedDebug.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68641abe552c8329873875215e4efb61