### PR TITLE
Enhance weekly need debug information

### DIFF
--- a/utils/mealNeedsCalculator.js
+++ b/utils/mealNeedsCalculator.js
@@ -4,6 +4,7 @@ import {
   loadMealsPerDay,
   initializeMealCategories
 } from './mealData.js';
+import { canonicalName } from './nameUtils.js';
 import { loadJSON } from './dataLoader.js';
 import { loadUsers, loadUserCategoryDays } from './userData.js';
 
@@ -59,22 +60,33 @@ export async function calculateAndSaveMealNeeds() {
 
     active.forEach(meal => {
       if (Array.isArray(meal.users)) {
+        const usersForMeal = meal.users
+          .map((use, idx) => (use ? idx : -1))
+          .filter(idx => idx >= 0);
         let personDays = 0;
-        meal.users.forEach((use, idx) => {
-          if (!use) return;
+        usersForMeal.forEach(idx => {
           const val = parseFloat(userDays[idx]?.[type]);
           personDays += isNaN(val) ? 1 : val;
         });
         if (personDays <= 0) return;
+        const people = usersForMeal.length;
+        const daysPerWeek = people > 0 ? personDays / people : 0;
         const monthlySpots = (perDay * personDays * 52) / active.length / 12;
         (meal.ingredients || []).forEach(ing => {
           const serving = parseAmount(ing.serving_size || ing.amount);
           if (!serving) return;
+          const key = canonicalName(ing.name);
           const need = serving * monthlySpots;
-          monthlyMap[ing.name] = (monthlyMap[ing.name] || 0) + need;
-          if (!monthlyBreakdown[ing.name]) monthlyBreakdown[ing.name] = {};
-          monthlyBreakdown[ing.name][meal.name] =
-            (monthlyBreakdown[ing.name][meal.name] || 0) + need;
+          monthlyMap[key] = (monthlyMap[key] || 0) + need;
+          if (!monthlyBreakdown[key]) monthlyBreakdown[key] = {};
+          monthlyBreakdown[key][meal.name] = {
+            monthlyNeed: need,
+            A: perDay,
+            B: people,
+            C: daysPerWeek,
+            D: active.length,
+            servingSize: serving
+          };
         });
       } else {
         const people = meal.people ?? meal.multiplier ?? 1;
@@ -94,11 +106,18 @@ export async function calculateAndSaveMealNeeds() {
         (meal.ingredients || []).forEach(ing => {
           const serving = parseAmount(ing.serving_size || ing.amount);
           if (!serving) return;
+          const key = canonicalName(ing.name);
           const need = serving * monthlySpots;
-          monthlyMap[ing.name] = (monthlyMap[ing.name] || 0) + need;
-          if (!monthlyBreakdown[ing.name]) monthlyBreakdown[ing.name] = {};
-          monthlyBreakdown[ing.name][meal.name] =
-            (monthlyBreakdown[ing.name][meal.name] || 0) + need;
+          monthlyMap[key] = (monthlyMap[key] || 0) + need;
+          if (!monthlyBreakdown[key]) monthlyBreakdown[key] = {};
+          monthlyBreakdown[key][meal.name] = {
+            monthlyNeed: need,
+            A: perDay,
+            B: people,
+            C: avgDays,
+            D: active.length,
+            servingSize: serving
+          };
         });
       }
     });

--- a/weeklyNeedDebug.js
+++ b/weeklyNeedDebug.js
@@ -28,7 +28,20 @@ document.addEventListener('DOMContentLoaded', async () => {
     `${meal.toFixed(2)} (meal plan monthly consumption)`
   ];
   Object.keys(breakdown).forEach(m => {
-    lines.push(`  - ${m}: ${breakdown[m].toFixed(2)}`);
+    const info = breakdown[m];
+    if (info && typeof info === 'object') {
+      const a = info.A ?? 0;
+      const b = info.B ?? 0;
+      const c = info.C ?? 0;
+      const d = info.D ?? 1;
+      const need = info.monthlyNeed ?? (parseFloat(info) || 0);
+      lines.push(
+        `  - ${m}: ${need.toFixed(2)} (A=${a}, B=${b}, C=${c}, D=${d})`
+      );
+    } else {
+      const val = parseFloat(info) || 0;
+      lines.push(`  - ${m}: ${val.toFixed(2)}`);
+    }
   });
   lines.push(
     `${(base + meal).toFixed(2)} (combined monthly consumption)`,


### PR DESCRIPTION
## Summary
- canonicalize ingredient names when computing meal plan needs
- track per-meal variables (A, B, C, D) correctly in breakdown

## Testing
- `node -c utils/mealNeedsCalculator.js`
- `node -c weeklyNeedDebug.js`


------
https://chatgpt.com/codex/tasks/task_e_68641de0be108329b0f07cad5e5adcbc