### PR TITLE
Enhance meal breakdown debug output

### DIFF
--- a/utils/mealNeedsCalculator.js
+++ b/utils/mealNeedsCalculator.js
@@ -52,55 +52,49 @@ export async function calculateAndSaveMealNeeds() {
     if (!active.length) continue;
     const perDay = mealsPerDay[type] ?? DEFAULT_MEALS_PER_DAY[type];
 
-    // Precompute how many meals each user is subscribed to for this category
-    const userCounts = users.map((_, idx) =>
-      active.filter(m => Array.isArray(m.users) && m.users[idx]).length
-    );
-
     active.forEach(meal => {
+      const details = {
+        perDay,
+        activeMeals: active.length,
+        factors: []
+      };
+      let personDays = 0;
+
       if (Array.isArray(meal.users)) {
-        let personDays = 0;
         meal.users.forEach((use, idx) => {
           if (!use) return;
           const val = parseFloat(userDays[idx]?.[type]);
-          personDays += isNaN(val) ? 1 : val;
-        });
-        if (personDays <= 0) return;
-        const monthlySpots = (perDay * personDays * 52) / active.length / 12;
-        (meal.ingredients || []).forEach(ing => {
-          const serving = parseAmount(ing.serving_size || ing.amount);
-          if (!serving) return;
-          const need = serving * monthlySpots;
-          monthlyMap[ing.name] = (monthlyMap[ing.name] || 0) + need;
-          if (!monthlyBreakdown[ing.name]) monthlyBreakdown[ing.name] = {};
-          monthlyBreakdown[ing.name][meal.name] =
-            (monthlyBreakdown[ing.name][meal.name] || 0) + need;
+          const days = isNaN(val) ? 1 : val;
+          details.factors.push({ people: 1, days });
+          personDays += days;
         });
       } else {
         const people = meal.people ?? meal.multiplier ?? 1;
         if (people <= 0) return;
-
         const avgDays =
           users.length > 0
-            ?
-                users.reduce((sum, _u, idx) => {
-                  const d = parseFloat(userDays[idx]?.[type]);
-                  return sum + (isNaN(d) ? 1 : d);
-                }, 0) / users.length
+            ? users.reduce((sum, _u, idx) => {
+                const d = parseFloat(userDays[idx]?.[type]);
+                return sum + (isNaN(d) ? 1 : d);
+              }, 0) / users.length
             : 1;
-
-        const personDays = people * avgDays;
-        const monthlySpots = (perDay * personDays * 52) / active.length / 12;
-        (meal.ingredients || []).forEach(ing => {
-          const serving = parseAmount(ing.serving_size || ing.amount);
-          if (!serving) return;
-          const need = serving * monthlySpots;
-          monthlyMap[ing.name] = (monthlyMap[ing.name] || 0) + need;
-          if (!monthlyBreakdown[ing.name]) monthlyBreakdown[ing.name] = {};
-          monthlyBreakdown[ing.name][meal.name] =
-            (monthlyBreakdown[ing.name][meal.name] || 0) + need;
-        });
+        details.factors.push({ people, days: avgDays });
+        personDays = people * avgDays;
       }
+
+      if (personDays <= 0) return;
+      const monthlySpots = (perDay * personDays * 52) / active.length / 12;
+      (meal.ingredients || []).forEach(ing => {
+        const serving = parseAmount(ing.serving_size || ing.amount);
+        if (!serving) return;
+        const need = serving * monthlySpots;
+        monthlyMap[ing.name] = (monthlyMap[ing.name] || 0) + need;
+        if (!monthlyBreakdown[ing.name]) monthlyBreakdown[ing.name] = {};
+        if (!monthlyBreakdown[ing.name][meal.name]) {
+          monthlyBreakdown[ing.name][meal.name] = { amount: 0, details };
+        }
+        monthlyBreakdown[ing.name][meal.name].amount += need;
+      });
     });
   }
   const yearlyMap = {};

--- a/weeklyNeedDebug.js
+++ b/weeklyNeedDebug.js
@@ -28,7 +28,16 @@ document.addEventListener('DOMContentLoaded', async () => {
     `${meal.toFixed(2)} (meal plan monthly consumption)`
   ];
   Object.keys(breakdown).forEach(m => {
-    lines.push(`  - ${m}: ${breakdown[m].toFixed(2)}`);
+    const entry = breakdown[m];
+    const amount = typeof entry === 'number' ? entry : entry.amount;
+    lines.push(`  - ${m}: ${amount.toFixed(2)}`);
+    if (entry && entry.details) {
+      const A = entry.details.perDay;
+      const factors = (entry.details.factors || [])
+        .map(f => `(${f.people} * ${f.days})`)
+        .join(' + ');
+      lines.push(`    ${A} * (${factors}) * 52 / 12`);
+    }
   });
   lines.push(
     `${(base + meal).toFixed(2)} (combined monthly consumption)`,


### PR DESCRIPTION
## Summary
- include detailed meal math variables in mealPlanMonthlyBreakdown
- display the formula for each meal in weekly need debug output

## Testing
- `node -c utils/mealNeedsCalculator.js`
- `node -c weeklyNeedDebug.js`

------
https://chatgpt.com/codex/tasks/task_e_686423e12ae08329af00c985b394c944