### PR TITLE
Improve monthly need debug output

### DIFF
--- a/weeklyNeedDebug.js
+++ b/weeklyNeedDebug.js
@@ -32,17 +32,30 @@ document.addEventListener('DOMContentLoaded', async () => {
     const amount = typeof entry === 'number' ? entry : entry.amount;
     lines.push(`  - ${m}: ${amount.toFixed(2)}`);
     if (entry && entry.details) {
-      const A = entry.details.perDay;
-      const factors = (entry.details.factors || [])
+      const perDay = entry.details.perDay;
+      const active = entry.details.activeMeals || 1;
+      const factors = entry.details.factors || [];
+      const factorExpr = factors
         .map(f => `(${f.people} * ${f.days})`)
         .join(' + ');
-      lines.push(`    ${A} * (${factors}) * 52 / 12`);
+      const factorVal = factors.reduce((sum, f) => sum + f.people * f.days, 0);
+      const spots = (perDay * factorVal * 52) / active / 12;
+      const serving = spots ? amount / spots : 0;
+      lines.push(
+        `    spots: ${perDay} * (${factorExpr}) * 52 / ${active} / 12 = ${spots.toFixed(
+          2
+        )}`
+      );
+      lines.push(
+        `    need: ${spots.toFixed(2)} * ${serving.toFixed(2)} = ${amount.toFixed(2)}`
+      );
     }
   });
   lines.push(
     `${(base + meal).toFixed(2)} (combined monthly consumption)`,
-    `${wpm.toFixed(2)} (weeks per month)`,
-    `${weekly.toFixed(2)} (weekly need)`
+    `${(base + meal).toFixed(2)} / ${wpm.toFixed(2)} = ${weekly.toFixed(
+      2
+    )} per week`
   );
   document.getElementById('item').textContent = item;
   document.getElementById('info').textContent = lines.join('\n');


### PR DESCRIPTION
## Summary
- expand `weeklyNeedDebug` info output to show full spot calculation and weekly math

## Testing
- `node --check weeklyNeedDebug.js`


------
https://chatgpt.com/codex/tasks/task_e_68642ed69c4883298a97d180d1d96b92