### PR TITLE
Add factor detail in weekly need debug

### DIFF
--- a/weeklyNeedDebug.js
+++ b/weeklyNeedDebug.js
@@ -35,6 +35,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       const perDay = entry.details.perDay;
       const active = entry.details.activeMeals || 1;
       const factors = entry.details.factors || [];
+      lines.push(`    per day: ${perDay}`);
+      lines.push(`    active meals: ${active}`);
+      factors.forEach(f =>
+        lines.push(`    factor: ${f.people} people * ${f.days} days`)
+      );
       const factorExpr = factors
         .map(f => `(${f.people} * ${f.days})`)
         .join(' + ');


### PR DESCRIPTION
## Summary
- show per-day, active meal, and factor lines in weekly need breakdown window

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686529dd3b7c8329a15eeec894966e2c