### PR TITLE
Improve weekly need breakdown details

### DIFF
--- a/inventoryTimeline.js
+++ b/inventoryTimeline.js
@@ -296,17 +296,22 @@ function buildGrid(items, headerState = {}, startWeek = 1) {
       `<br/><span class="weekly-cons">${item.weekly_consumption.toFixed(2)}/wk</span>`;
     const span = th.querySelector('.weekly-cons');
     if (span) {
-      span.style.cursor = 'pointer';
-      span.addEventListener('click', () => {
-        const params = new URLSearchParams({
-          item: item.name,
-          base: item.base_monthly_consumption ?? 0,
-          meal: item.meal_monthly_consumption ?? 0,
-          weekly: item.weekly_consumption,
-          wpm: WEEKS_PER_MONTH
+      const hasDetails = Object.values(item.meal_breakdown || {}).some(
+        e => e && e.details
+      );
+      if (hasDetails) {
+        span.style.cursor = 'pointer';
+        span.addEventListener('click', () => {
+          const params = new URLSearchParams({
+            item: item.name,
+            base: item.base_monthly_consumption ?? 0,
+            meal: item.meal_monthly_consumption ?? 0,
+            weekly: item.weekly_consumption,
+            wpm: WEEKS_PER_MONTH
+          });
+          openOrFocusWindow(`weeklyNeedDebug.html?${params.toString()}`, 320, 240);
         });
-        openOrFocusWindow(`weeklyNeedDebug.html?${params.toString()}`, 320, 240);
-      });
+      }
     }
     row.appendChild(th);
     weeks.forEach((w, idx) => {

--- a/weeklyNeedDebug.js
+++ b/weeklyNeedDebug.js
@@ -23,39 +23,37 @@ document.addEventListener('DOMContentLoaded', async () => {
   const wpm = parseFloat(params.get('wpm') || '4.33');
   const weekly = parseFloat(params.get('weekly') || (base + meal) / wpm);
   const breakdown = await loadBreakdown(key);
+  const hasDetails = Object.values(breakdown).some(b => b && b.details);
+  if (!hasDetails) {
+    window.close();
+    return;
+  }
   const lines = [
     `${base.toFixed(2)} (base monthly consumption)`,
     `${meal.toFixed(2)} (meal plan monthly consumption)`
   ];
   Object.keys(breakdown).forEach(m => {
     const entry = breakdown[m];
+    if (!entry || !entry.details) return;
     const amount = typeof entry === 'number' ? entry : entry.amount;
+    const perDay = entry.details.perDay;
+    const active = entry.details.activeMeals || 1;
+    const factors = entry.details.factors || [];
+    const factorExpr = factors.map(f => `(${f.people} * ${f.days})`).join(' + ');
+    const factorVal = factors.reduce((sum, f) => sum + f.people * f.days, 0);
+    const spots = (perDay * factorVal * 52) / active / 12;
+    const serving = spots ? amount / spots : 0;
     lines.push(`  - ${m}: ${amount.toFixed(2)}`);
-    if (entry && entry.details) {
-      const perDay = entry.details.perDay;
-      const active = entry.details.activeMeals || 1;
-      const factors = entry.details.factors || [];
-      const factorExpr = factors
-        .map(f => `(${f.people} * ${f.days})`)
-        .join(' + ');
-      const factorVal = factors.reduce((sum, f) => sum + f.people * f.days, 0);
-      const spots = (perDay * factorVal * 52) / active / 12;
-      const serving = spots ? amount / spots : 0;
-      lines.push(
-        `    spots: ${perDay} * (${factorExpr}) * 52 / ${active} / 12 = ${spots.toFixed(
-          2
-        )}`
-      );
-      lines.push(
-        `    need: ${spots.toFixed(2)} * ${serving.toFixed(2)} = ${amount.toFixed(2)}`
-      );
-    }
+    lines.push(`    perDay: ${perDay}`);
+    lines.push(`    activeMeals: ${active}`);
+    lines.push(`    factors: ${factorExpr} = ${factorVal.toFixed(2)}`);
+    lines.push(`    spots: ${perDay} * (${factorExpr}) * 52 / ${active} / 12 = ${spots.toFixed(2)}`);
+    lines.push(`    serving: ${serving.toFixed(2)}`);
+    lines.push(`    need: ${spots.toFixed(2)} * ${serving.toFixed(2)} = ${amount.toFixed(2)}`);
   });
   lines.push(
     `${(base + meal).toFixed(2)} (combined monthly consumption)`,
-    `${(base + meal).toFixed(2)} / ${wpm.toFixed(2)} = ${weekly.toFixed(
-      2
-    )} per week`
+    `${(base + meal).toFixed(2)} / ${wpm.toFixed(2)} = ${weekly.toFixed(2)} per week`
   );
   document.getElementById('item').textContent = item;
   document.getElementById('info').textContent = lines.join('\n');


### PR DESCRIPTION
## Summary
- disable weekly need popup when breakdown info is absent
- show intermediate values for each meal's need calculation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686536747a348329a69ebc742595fbcd